### PR TITLE
Fix services

### DIFF
--- a/contracts/account_service.py
+++ b/contracts/account_service.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+from rpc_service import ErrorResponse, RpcMessageGroup, ResponseMessage, RpcContract, endpoint
+
+
+messages = RpcMessageGroup()
+
+
+@messages.add_message_type
+class AccountInfo(ResponseMessage):
+    username: str
+    rating: int
+
+
+@messages.add_message_type
+@dataclass
+class AlreadyExists(ErrorResponse):
+    username: str
+    _message: str = 'Username {username!r} taken'
+
+
+@messages.add_message_type
+@dataclass
+class NotExists(ErrorResponse):
+    username: str
+    _message: str = 'Account with username {username!r} not exists'
+
+
+class Contract(RpcContract):
+    __service__ = 'accounts_service'
+    __messages__ = messages
+
+    @endpoint
+    async def create_account(self, username: str) -> AccountInfo:
+        """
+        Создает аккаунт с указанным именем
+
+        :param username: имя аккаунта
+        :raise AlreadyExists: если указанное имя уже занято
+        """
+        raise NotImplementedError()
+
+    @endpoint
+    async def update_account(self, updated_data: AccountInfo) -> AccountInfo:
+        """
+        Обновляет информацию об аккаунте
+
+        :raise NotExists: если аккаунта с таким именем не существует
+        :param updated_data: обновленная информация
+        :return: результат обновления информации
+        """
+        raise NotImplementedError()
+
+    @endpoint
+    async def get_account(self, username: str) -> AccountInfo:
+        """
+        Получение аккаунта с указанным именем
+
+        :raise NotExists: если аккаунта с таким именем не существует
+        :param username: имя аккаунта, которого ищем
+        """
+        raise NotImplementedError()
+
+    @endpoint
+    async def delete_account(self, username: str):
+        """
+        Удаление аккаунта с указанным именем
+
+        :raise NotExists: если аккаунта с таким именем нет
+        :param username: имя аккаунта, который удаляем
+        """
+        raise NotImplementedError()

--- a/contracts/auth_service.py
+++ b/contracts/auth_service.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+from rpc_service import ErrorResponse, RpcMessageGroup, ResponseMessage, RpcContract, endpoint
+
+
+messages = RpcMessageGroup()
+
+
+@messages.add_message_type
+@dataclass
+class UsernameTaken(ErrorResponse):
+    username: str
+    _message: str = 'Username {username!r} taken'
+
+
+@messages.add_message_type
+@dataclass
+class InvalidCredentials(ErrorResponse):
+    _message: str = 'Invalid username or password'
+
+
+@messages.add_message_type
+@dataclass
+class InvalidToken(ErrorResponse):
+    token: str
+    _message: str = 'Token {token!r} invalid'
+
+
+@messages.add_message_type
+class Token(ResponseMessage):
+    access_token: str
+    token_type: str
+
+
+@messages.add_message_type
+class TokenData(ResponseMessage):
+    username: str
+
+
+class Contract(RpcContract):
+    __service__ = 'auth_service'
+    __messages__ = messages
+
+    @endpoint
+    async def register_user(self, login: str, password: str) -> Token:
+        """
+        Регистрация пользователя
+
+        :param login: логин пользователя
+        :param password: пароль пользователя
+        :return: сгенерированный токен доступа
+        :raise UsernameTaken: пользователь с указанным логином уже зарегестрирован
+        """
+        raise NotImplementedError()
+
+    @endpoint
+    async def generate_access_token(self, login: str, password: str) -> Token:
+        """
+        Авторизация пользователя
+
+        :param login: логин пользователя
+        :param password: пароль пользователя
+        :return: сгенерированный токен доступа
+        :raise InvalidCredentials: переданы неверные данные для входа
+        """
+        raise NotImplementedError()
+
+    @endpoint
+    async def authenticate(self, token: str) -> TokenData:
+        """
+        Аутентификация пользователя по токену доступа
+
+        :param token: токен доступа
+        :return: данные, хранящиеся в токене
+        :raise InvalidToken: отправленный токен неверный
+        """
+        raise NotImplementedError()

--- a/contracts/private_room_service.py
+++ b/contracts/private_room_service.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from rpc_service import RpcMessageGroup, ResponseMessage, ErrorResponse, RpcContract, endpoint
+
+
+messages = RpcMessageGroup()
+
+
+@messages.add_message_type
+class PrivateRoomInfo(ResponseMessage):
+    connection_key: str
+
+
+@messages.add_message_type
+@dataclass
+class RoomNotFound(ErrorResponse):
+    connection_key: str
+    _message: str = 'Room with connection key {connection_key!r} not found'
+
+
+@messages.add_message_type
+@dataclass
+class PlayerNotConnected(ErrorResponse):
+    connection_key: str
+    player_name: str
+    _message: str = 'Player {player_name!r} not connected to room {connection_key!r}'
+
+
+class Contract(RpcContract):
+    __service__ = 'private_rooms'
+    __messages__ = messages
+
+    @endpoint
+    async def create(self, player_name: str) -> PrivateRoomInfo:
+        raise NotImplementedError()
+
+    @endpoint
+    async def connect_room(self, player_name: str, connection_key: str):
+        raise NotImplementedError()
+
+    @endpoint
+    async def disconnect_room(self, player_name: str, connection_key: str):
+        raise NotImplementedError()

--- a/contracts/searcher_service.py
+++ b/contracts/searcher_service.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+import pydantic
+from rpc_service import RpcMessageGroup, ErrorResponse, RpcContract, endpoint
+
+
+messages = RpcMessageGroup()
+
+
+class SearchParameters(pydantic.BaseModel):
+    min_rating: int
+    max_rating: int
+
+
+class CallerInfo(pydantic.BaseModel):
+    name: str
+    rating: int
+
+
+@messages.add_message_type
+@dataclass
+class SearchAlreadyStarted(ErrorResponse):
+    caller: CallerInfo
+    _message: str = 'Search already started. Please, cancel last search'
+
+
+@messages.add_message_type
+@dataclass
+class SearchNotStarted(ErrorResponse):
+    caller: CallerInfo
+    _message: str = 'Search not started'
+
+
+class Contract(RpcContract):
+    __service__ = 'searcher_service'
+    __messages__ = messages
+
+    @endpoint
+    async def start_search(self, caller: CallerInfo, parameters: SearchParameters):
+        raise NotImplementedError()
+
+    @endpoint
+    async def cancel_search(self, caller: CallerInfo):
+        raise NotImplementedError()

--- a/contracts/session_service.py
+++ b/contracts/session_service.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass
+import pydantic
+
+from game_model.game.model import GameState
+from rpc_service import ErrorResponse, RpcMessageGroup, ResponseMessage, RpcContract, endpoint
+from state_encoder import StateEncoder
+
+
+messages = RpcMessageGroup()
+
+
+@messages.add_message_type
+@dataclass
+class AccessDenied(ErrorResponse):
+    session_id: int
+    player_name: str
+    _message: str = 'Player {player_name!r} not connected to session {session_id!r}'
+
+
+@messages.add_message_type
+@dataclass
+class NotExists(ErrorResponse):
+    session_id: int
+    _message: str = 'Session with id {session_id} not exists'
+
+
+@messages.add_message_type
+@dataclass
+class ExecuteCommandError(ErrorResponse):
+    description: str
+    _message: str = 'Enable to execute command. Reason: {description}'
+
+
+@messages.add_message_type
+class Session(ResponseMessage):
+    session_id: int
+    first_player: str
+    second_player: str
+
+
+@messages.add_message_type
+class GameStateResponse(ResponseMessage):
+    state: GameState
+
+    @pydantic.validator('state', pre=True)
+    def _deserialize_state(cls, serialized):
+        if isinstance(serialized, dict):
+            return StateEncoder.decode(serialized)
+        return serialized
+
+    class Config:
+        arbitrary_types_allowed = True
+        json_encoders = {
+            GameState: StateEncoder.encode
+        }
+
+
+class Contract(RpcContract):
+    __service__ = 'session_service'
+    __messages__ = messages
+
+    @endpoint
+    async def create_session(self, first_player: str, second_player: str) -> Session:
+        raise NotImplementedError()
+
+    @endpoint
+    async def connect_to_session(self, session_id: int, player_name: str):
+        raise NotImplementedError()
+
+    @endpoint
+    async def disconnect_from_session(self, session_id: int, player_name: str):
+        raise NotImplementedError()
+
+    @endpoint
+    async def execute_command(self, session_id: int, player_name: str, command: dict):
+        raise NotImplementedError()
+
+    @endpoint
+    async def get_session_game_state(self, session_id: int) -> GameStateResponse:
+        raise NotImplementedError()

--- a/services/accounts_service/domain/__init__.py
+++ b/services/accounts_service/domain/__init__.py
@@ -1,0 +1,15 @@
+from .adapters import AccountStorage, AlreadyExists, NotExists
+from .models import AccountModel
+from .usecases import CreateAccount, GetAccount, UpdateAccount, RemoveAccount
+
+
+__all__ = [
+    "AccountStorage",
+    "AlreadyExists",
+    "NotExists",
+    "AccountModel",
+    "CreateAccount",
+    "GetAccount",
+    "UpdateAccount",
+    "RemoveAccount"
+]

--- a/services/accounts_service/domain/adapters.py
+++ b/services/accounts_service/domain/adapters.py
@@ -30,17 +30,17 @@ class NotExists(Exception):
 
 class AccountStorage(ABC):
     @abstractmethod
-    def create(self, username: str) -> AccountModel:
+    async def create(self, username: str) -> AccountModel:
         raise NotImplementedError()
 
     @abstractmethod
-    def get(self, username: str) -> AccountModel:
+    async def get(self, username: str) -> AccountModel:
         raise NotImplementedError()
 
     @abstractmethod
-    def update(self, updated_data: AccountModel) -> AccountModel:
+    async def update(self, updated_data: AccountModel) -> AccountModel:
         raise NotImplementedError()
 
     @abstractmethod
-    def remove(self, username: str):
+    async def remove(self, username: str):
         raise NotImplementedError()

--- a/services/accounts_service/domain/models.py
+++ b/services/accounts_service/domain/models.py
@@ -27,3 +27,6 @@ class AccountModel:
         if value < 0:
             raise ValueError('Rating must be positive or 0')
         self._rating = value
+
+    def __repr__(self):
+        return f'{type(self).__name__}(username={self.username!r}, rating={self.rating!r})'

--- a/services/accounts_service/domain/usecases.py
+++ b/services/accounts_service/domain/usecases.py
@@ -8,8 +8,8 @@ class CreateAccount:
     def __init__(self, storage: AccountStorage):
         self._storage = storage
 
-    def __call__(self, username: str) -> AccountModel:
-        return self._storage.create(username)
+    async def __call__(self, username: str) -> AccountModel:
+        return await self._storage.create(username)
 
 
 class RemoveAccount:
@@ -18,8 +18,8 @@ class RemoveAccount:
     def __init__(self, storage: AccountStorage):
         self._storage = storage
 
-    def __call__(self, username: str):
-        self._storage.remove(username)
+    async def __call__(self, username: str):
+        await self._storage.remove(username)
 
 
 class GetAccount:
@@ -28,8 +28,8 @@ class GetAccount:
     def __init__(self, storage: AccountStorage):
         self._storage = storage
 
-    def __call__(self, username: str) -> AccountModel:
-        return self._storage.get(username)
+    async def __call__(self, username: str) -> AccountModel:
+        return await self._storage.get(username)
 
 
 class UpdateAccount:
@@ -38,5 +38,5 @@ class UpdateAccount:
     def __init__(self, storage: AccountStorage):
         self._storage = storage
 
-    def __call__(self, updated: AccountModel) -> AccountModel:
-        return self._storage.update(updated)
+    async def __call__(self, updated: AccountModel) -> AccountModel:
+        return await self._storage.update(updated)

--- a/services/accounts_service/infrastructure/__init__.py
+++ b/services/accounts_service/infrastructure/__init__.py
@@ -1,0 +1,6 @@
+from .account_database import AccountDatabase
+
+
+__all__ = [
+    "AccountDatabase"
+]

--- a/services/accounts_service/infrastructure/account_database.py
+++ b/services/accounts_service/infrastructure/account_database.py
@@ -1,0 +1,61 @@
+from tortoise import Model, fields, Tortoise
+from services.accounts_service.domain import adapters, AccountModel
+from settings import settings
+
+
+class AccountDBModel(Model):
+    """Tortoise модель представления данных об аккаунте пользователя"""
+
+    id = fields.IntField(pk=True)
+    username = fields.CharField(max_length=50, unique=True)
+    rating = fields.IntField(default=0)
+
+
+class AccountDatabase:
+    """Реализация хранилища аккаунтов на основе Postgres и Tortoise ORM"""
+
+    @staticmethod
+    async def connect():
+        await Tortoise.init(
+            db_url=settings.postgres_dsn,
+            modules={'models': ['services.accounts_service.infrastructure.account_database']}
+        )
+
+        await Tortoise.generate_schemas()
+
+    async def create(self, username: str) -> AccountModel:
+        is_exists = await AccountDBModel.filter(username=username).exists()
+
+        if is_exists:
+            raise adapters.AlreadyExists(username=username)
+
+        created_record = await AccountDBModel.create(username=username)
+        return AccountModel(username=created_record.username, rating=created_record.rating)
+
+    async def get(self, username: str) -> AccountModel:
+        record = await AccountDBModel.filter(username=username).first()
+
+        if record is None:
+            raise adapters.NotExists(username=username)
+
+        return AccountModel(username=record.username, rating=record.rating)
+
+    async def update(self, updated_data: AccountModel) -> AccountModel:
+        record = await AccountDBModel.filter(username=updated_data.username).first()
+
+        if record is None:
+            raise adapters.NotExists(username=updated_data.username)
+
+        record.username = updated_data.username
+        record.rating = updated_data.rating
+        await record.save()
+
+        return await self.get(updated_data.username)
+
+    async def remove(self, username: str):
+        record = await AccountDBModel.filter(username=username).first()
+
+        if record is None:
+            raise adapters.NotExists(username=username)
+
+        await record.delete()

--- a/services/accounts_service/main.py
+++ b/services/accounts_service/main.py
@@ -1,88 +1,23 @@
-# Response Models
 import asyncio
 
-from pydantic import BaseModel
-
-from rpc_service.handler import ResponseError
-from rpc_service.service import RPCService
-from services.accounts_service.domain.adapters import AlreadyExists, NotExists
-from services.accounts_service.domain.usecases import *
-from services.accounts_service.infrastracture import DefaultAccountDatabase
-
-
-class AccountInfo(BaseModel):
-    username: str
-    rating: int
+from contracts import account_service
+from rpc_service.utils import ServiceLauncher
+from services.accounts_service.infrastructure import AccountDatabase
+from services.accounts_service.methods import Implementation
+from rpc_service import RpcServiceBuilder
+from settings import settings
 
 
-class ResponseMessage(BaseModel):
-    message_type: str
-    detail: str
-
-
-# Variables
-
-db = DefaultAccountDatabase()
-
-# Endpoints
-
-
-async def create_user(username: str) -> AccountInfo:
-    try:
-        account = CreateAccount(db)(username)
-    except AlreadyExists as e:
-        raise ResponseError(error_type="already_exists", detail=f"Account with name '{username}' already exists")
-
-    response = AccountInfo(username=account.username, rating=account.rating)
-    return response
-
-
-async def get_user(username: str) -> AccountInfo:
-    try:
-        account = GetAccount(db)(username)
-    except NotExists as e:
-        raise ResponseError(error_type="not_exists", detail=f"Account with username '{username}' doesn't exist")
-
-    response = AccountInfo(username=account.username, rating=account.rating)
-    return response
-
-
-async def update_user(updated_data: AccountInfo) -> AccountInfo:
-    try:
-        account = AccountModel(**updated_data.dict())
-        updated_account = UpdateAccount(db)(account)
-    except NotExists as e:
-        raise ResponseError(
-            error_type="not_exists",
-            detail=f"Account with username '{updated_data.username}' doesn't exist")
-
-    response = AccountInfo(username=updated_account.username, rating=updated_account.rating)
-    return response
-
-
-async def remove_user(username: str):
-    try:
-        RemoveAccount(db)(username)
-    except NotExists as e:
-        raise ResponseError(error_type="not_exists", detail=f"Account with username '{username}' doesn't exist")
-
-    response = ResponseMessage(message_type="success", detail="Successful")
-    return response
-
-
-# Service
-
-service = RPCService("accounts_service", "amqp://guest:guest@localhost")
-service.bind("create", create_user)
-service.bind("get", get_user)
-service.bind("update", update_user)
-service.bind("remove", remove_user)
+db = AccountDatabase()
+implementation = Implementation(storage=db)
+service = RpcServiceBuilder.from_contract(implementation, account_service.Contract)
+launcher = ServiceLauncher(service)
 
 
 async def main():
-    await service.run()
-    await asyncio.Future()
+    await db.connect()
+    await launcher.start(settings.amqp_dsn)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     asyncio.run(main())

--- a/services/accounts_service/methods.py
+++ b/services/accounts_service/methods.py
@@ -1,0 +1,46 @@
+from contracts import account_service
+from services.accounts_service import domain
+from services.accounts_service.domain import adapters
+
+
+class Implementation(account_service.Contract):
+    def __init__(self, storage: adapters.AccountStorage):
+        self._storage = storage
+
+    async def create_account(self, username: str) -> account_service.AccountInfo:
+        try:
+            account = await domain.CreateAccount(self._storage)(username)
+
+        except domain.AlreadyExists:
+            raise account_service.AlreadyExists(username=username)
+
+        response = account_service.AccountInfo(username=account.username, rating=account.rating)
+        return response
+
+    async def update_account(self, updated_data: account_service.AccountInfo) -> account_service.AccountInfo:
+        try:
+            account = domain.AccountModel(**updated_data.dict())
+            updated_account = await domain.UpdateAccount(self._storage)(account)
+
+        except domain.NotExists:
+            raise account_service.NotExists(username=updated_data.username)
+
+        response = account_service.AccountInfo(username=updated_account.username, rating=updated_account.rating)
+        return response
+
+    async def get_account(self, username: str) -> account_service.AccountInfo:
+        try:
+            account = await domain.GetAccount(self._storage)(username)
+
+        except domain.NotExists:
+            raise account_service.NotExists(username=username)
+
+        response = account_service.AccountInfo(username=account.username, rating=account.rating)
+        return response
+
+    async def delete_account(self, username: str):
+        try:
+            await domain.RemoveAccount(self._storage)(username)
+
+        except domain.NotExists:
+            raise account_service.NotExists(username=username)

--- a/services/auth_service/domain/__init__.py
+++ b/services/auth_service/domain/__init__.py
@@ -1,0 +1,13 @@
+from .models import CredentialsModel
+from .usecases import RegisterUser, AuthorizeUser, AuthenticateUser
+from .adapters import ValidateMethod, CredentialsStorage
+
+
+__all__ = [
+    'CredentialsModel',
+    'RegisterUser',
+    'AuthenticateUser',
+    'AuthorizeUser',
+    'ValidateMethod',
+    'CredentialsStorage'
+]

--- a/services/auth_service/domain/adapters/__init__.py
+++ b/services/auth_service/domain/adapters/__init__.py
@@ -1,0 +1,12 @@
+from .credentials_storage import CredentialsStorage, NotExists, AlreadyRegistered
+from .validate_method import InvalidAuthorizationData, InvalidAuthenticationData, ValidateMethod
+
+
+__all__ = [
+    'CredentialsStorage',
+    'NotExists',
+    'AlreadyRegistered',
+    'InvalidAuthenticationData',
+    'InvalidAuthorizationData',
+    'ValidateMethod'
+]

--- a/services/auth_service/domain/adapters/credentials_storage.py
+++ b/services/auth_service/domain/adapters/credentials_storage.py
@@ -1,0 +1,79 @@
+from abc import ABC, abstractmethod
+from services.auth_service.domain import models
+
+
+class NotExists(Exception):
+    """
+    Исключение, выбрасываемое хранилищем в момент, когда поиск
+    записи оказался неудачным
+
+    Arguments:
+        login - логин, по которому искалась запись
+    """
+    login: models.Login
+    __message: str = 'Record for user with login {login!r} not exists'
+
+    def __init__(self, login: models.Login):
+        super().__init__(self.__message.format(login=login))
+
+
+class AlreadyRegistered(Exception):
+    """
+    Исключение, выбрасываемое хранилищем в момент, когда добавляемый
+    пользователь уже был создан
+
+    Arguments:
+        credentials - данные для входа, которые нужно было добавить
+    """
+    credentials: models.CredentialsModel
+    __message: str = 'Credentials for user {login!r} already exist'
+
+    def __init__(self, credentials: models.CredentialsModel):
+        super().__init__(self.__message.format(login=credentials.login))
+        self.credentials = credentials
+
+
+class CredentialsStorage(ABC):
+    """
+    Адаптер к хранилищу данных для входа пользователей
+    """
+
+    @abstractmethod
+    async def create_record(self, credentials: models.CredentialsModel) -> models.CredentialsModel:
+        """
+        Создает запись с данными для входа пользователя в хранилище
+
+        :raise AlreadyRegistered: пользователь с таким же логином уже зарегестрирован
+        :param credentials: данные для входа пользователя
+        :return: данные, которые сохранились
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def remove_record(self, login: str):
+        """
+        Удаляет запись с данными для входа из хранилища
+        :param login: логин пользователя, данные которого удаляем
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def get_record(self, login: str) -> models.CredentialsModel:
+        """
+        Возвращает данные для входа пользователя по его логину
+        :param login: логин пользователя
+        :return: соответствующие данные для входа
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def validate(self, credentials: models.CredentialsModel):
+        """
+        Проверяет наличие переданных данных для входа в хранилище. В случае, если
+        было проверено успешно, ничего не возвращается.
+
+        :param credentials: данные для входа, которые проверяем
+        :raise NotExists: если не было найдено такой записи
+        """
+        raise NotImplementedError()
+

--- a/services/auth_service/domain/adapters/validate_method.py
+++ b/services/auth_service/domain/adapters/validate_method.py
@@ -1,0 +1,64 @@
+from abc import ABC, abstractmethod
+from .. import models
+
+
+class InvalidAuthenticationData(Exception):
+    """
+    Исключение, вызываемое методом проверки запрос для входа
+    когда данные для аутентификации неверные
+
+    Arguments:
+        data - данные для аутентификации, которые пришли
+    """
+
+    data: models.AuthenticationData
+    __message: str = 'Authentication data {data!r} invalid'
+
+    def __init__(self, data: models.AuthenticationData):
+        super().__init__(self.__message.format(data=data))
+        self.data = data
+
+
+class InvalidAuthorizationData(Exception):
+    """
+    Исключение, вызываемое методом проверки запросов для
+    входа когда данные для авторизации неверные
+
+    Arguments:
+        data - данные для авторизации, которые пришли
+    """
+
+    data: models.AuthorizationData
+    __message: str = 'Authorization data {data!r} invalid'
+
+    def __init__(self, data: models.AuthorizationData):
+        super().__init__(self.__message.format(data=data))
+        self.data = data
+
+
+class ValidateMethod(ABC):
+    """
+    Адаптер к методу проверки запросов для авторизации / аутентификации
+    """
+
+    @abstractmethod
+    async def validate(self, data: models.AuthenticationData) -> models.CredentialsModel:
+        """
+        Метод для аутентификации пользователя
+
+        :param data: данные для аутентификации
+        :return: данные для входа. Возвращаются в случае, если аутентификация прошла успешна
+        :raise InvalidAuthenticationData: не удалось аутентифицировать пользователя
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def authorize(self, data: models.AuthorizationData) -> models.AuthenticationData:
+        """
+        Метод для авторизации пользователя
+
+        :param data: данные для авторизации
+        :return: данные для аутентификации. Возвращаются в случае, если авторизация прошла успешно
+        :raise InvalidAuthenticationData: не удалось авторизовать пользователя
+        """
+        raise NotImplementedError()

--- a/services/auth_service/domain/models.py
+++ b/services/auth_service/domain/models.py
@@ -1,0 +1,37 @@
+from abc import ABC
+from dataclasses import dataclass
+from typing import NewType
+
+
+Login = NewType('Login', str)
+Password = NewType('Password', str)
+
+
+@dataclass(frozen=True)
+class CredentialsModel:
+    """
+    Бизнес модель данных для входа пользователя
+
+    Arguments:
+        username - имя пользователя
+        hashed_password - зашифрованный пароль
+    """
+
+    login: Login
+    password: Password
+
+
+class AuthenticationData(ABC):
+    """
+    Модель запроса, посылаемого для аутентификации пользователя. Конкретная реализация
+    уточняется в инфраструктуре на основе метода аутентификации
+    """
+    pass
+
+
+class AuthorizationData(ABC):
+    """
+    Модель запроса, посылаемого для авторизации пользователя. Конкретная реализация
+    уточняется в инфраструктуре на основе метода авторизации
+    """
+    pass

--- a/services/auth_service/domain/usecases.py
+++ b/services/auth_service/domain/usecases.py
@@ -1,0 +1,31 @@
+from services.auth_service.domain import adapters, models
+
+
+class RegisterUser:
+    _storage: adapters.CredentialsStorage
+
+    def __init__(self, storage: adapters.CredentialsStorage):
+        self._storage = storage
+
+    async def __call__(self, credentials: models.CredentialsModel) -> models.CredentialsModel:
+        return await self._storage.create_record(credentials)
+
+
+class AuthorizeUser:
+    _method: adapters.ValidateMethod
+
+    def __init__(self, method: adapters.ValidateMethod):
+        self._method = method
+
+    async def __call__(self, auth_data: models.AuthorizationData) -> models.AuthenticationData:
+        return await self._method.authorize(auth_data)
+
+
+class AuthenticateUser:
+    _method: adapters.ValidateMethod
+
+    def __init__(self, method: adapters.ValidateMethod):
+        self._method = method
+
+    async def __call__(self, auth_data: models.AuthenticationData) -> models.CredentialsModel:
+        return await self._method.validate(auth_data)

--- a/services/auth_service/infrastructure/__init__.py
+++ b/services/auth_service/infrastructure/__init__.py
@@ -1,0 +1,11 @@
+from .jwt_method import JWTMethod, JWTSecrets, Token, Authorize
+from .storage import CredentialsDatabase
+
+
+__all__ = [
+    'JWTSecrets',
+    'JWTMethod',
+    'Token',
+    'Authorize',
+    'CredentialsDatabase'
+]

--- a/services/auth_service/infrastructure/jwt_method.py
+++ b/services/auth_service/infrastructure/jwt_method.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+
+import jwt
+
+from ..domain import models
+from ..domain import adapters
+from ..domain.models import AuthenticationData, AuthorizationData, Login, Password
+
+
+@dataclass(frozen=True)
+class Token(AuthenticationData):
+    token: str
+
+
+@dataclass(frozen=True)
+class Authorize(AuthorizationData):
+    login: Login
+    password: Password
+
+
+@dataclass(frozen=True)
+class JWTSecrets:
+    key: str
+    algorithm: str
+
+
+class JWTMethod(adapters.ValidateMethod):
+    """
+    Метод аутентификации / авторизации пользователей на основе JWT токенов
+    """
+
+    _storage: adapters.CredentialsStorage
+    _secrets: JWTSecrets
+
+    def __init__(self, storage: adapters.CredentialsStorage, secrets: JWTSecrets):
+        self._storage = storage
+        self._secrets = secrets
+
+    async def validate(self, data: Token) -> models.CredentialsModel:
+        try:
+            decoded = jwt.decode(data.token, self._secrets.key, algorithms=[self._secrets.algorithm])
+            return await self._storage.get_record(decoded.get('login'))
+
+        except (jwt.DecodeError, TypeError):
+            raise adapters.InvalidAuthenticationData(data)
+
+    async def authorize(self, data: Authorize) -> Token:
+        try:
+            check_credentials = models.CredentialsModel(login=data.login, password=data.password)
+            await self._storage.validate(check_credentials)
+            token = jwt.encode({'login': data.login}, self._secrets.key, algorithm=self._secrets.algorithm)
+            return Token(token=token)
+
+        except adapters.NotExists:
+            raise adapters.InvalidAuthorizationData(data)

--- a/services/auth_service/infrastructure/storage.py
+++ b/services/auth_service/infrastructure/storage.py
@@ -1,0 +1,83 @@
+from passlib.context import CryptContext
+from tortoise import Model, fields, Tortoise
+
+from services.auth_service.domain.adapters import CredentialsStorage, AlreadyRegistered, NotExists
+from services.auth_service.domain.models import Password, Login
+from settings import settings
+from ..domain import models
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _hash_password(password: Password) -> Password:
+    """
+    Зашифровывает пароль, используя хеширование
+    :param password: изначальный вид пароля
+    :return: зашифрованный пароль
+    """
+
+    return pwd_context.hash(password)
+
+
+def _verify_password(plain_password: Password, hashed_password: Password) -> bool:
+    """
+    Проверяет верность указанного пароля на основе зашифрованной версии исходного
+
+    :param plain_password: пароль, который проверяем
+    :param hashed_password: зашифрованная версия исходного
+    :return: возвращает `True` в случае, если пароль верный, `False` - в противном
+    """
+
+    print(f'>>> {type(plain_password)}, {type(hashed_password)}')
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+class CredentialsDBModel(Model):
+    id = fields.IntField(pk=True)
+    login = fields.CharField(max_length=50, unique=True)
+    hashed_password = fields.CharField(max_length=200)
+
+
+class CredentialsDatabase(CredentialsStorage):
+    async def connect(self):
+        await Tortoise.init(
+            db_url=settings.postgres_dsn,
+            modules={'models': ['services.auth_service.infrastructure.storage']}
+        )
+
+        await Tortoise.generate_schemas()
+
+    async def create_record(self, credentials: models.CredentialsModel) -> models.CredentialsModel:
+        record = await CredentialsDBModel.filter(login=credentials.login).first()
+
+        if record is not None:
+            raise AlreadyRegistered(credentials=credentials)
+
+        created_record = await CredentialsDBModel.create(
+            login=credentials.login,
+            hashed_password=_hash_password(credentials.password))
+
+        return models.CredentialsModel(login=created_record.login, password=created_record.hashed_password)
+
+    async def remove_record(self, login: Login):
+        record = await CredentialsDBModel.filter(login=login).first()
+
+        if record is None:
+            raise NotExists(login)
+
+        await record.delete()
+
+    async def get_record(self, login: str) -> models.CredentialsModel:
+        record = await CredentialsDBModel.filter(login=login).first()
+
+        if record is None:
+            raise NotExists(login)
+
+        return models.CredentialsModel(login=record.login, password=record.hashed_password)
+
+    async def validate(self, credentials: models.CredentialsModel):
+        compare_credentials = await self.get_record(credentials.login)
+
+        if not _verify_password(credentials.password, str(compare_credentials.password)):
+            raise NotExists(login=credentials.login)

--- a/services/auth_service/main.py
+++ b/services/auth_service/main.py
@@ -1,139 +1,25 @@
 import asyncio
-from typing import Union
-
-import jwt
-from jwt import DecodeError
-from passlib.context import CryptContext
-from pydantic import BaseModel
-
-
-# Config
-from rpc_service.handler import ResponseError
-from rpc_service.service import RPCService
-
-SECRET_KEY = "MY_WIFE_LEFT_ME"
-ALGORITHM = "HS256"
+from contracts import auth_service
+from rpc_service import RpcServiceBuilder
+from rpc_service.utils import ServiceLauncher
+from services.auth_service import infrastructure
+from services.auth_service.methods import Implementation
+from settings import settings
 
 
-# Schemas
+db = infrastructure.CredentialsDatabase()
+secrets = infrastructure.JWTSecrets(key='MY_WIFE_LEFT_ME', algorithm='HS256')
+jwt = infrastructure.JWTMethod(db, secrets)
 
-
-class Registration(BaseModel):
-    username: str
-    password: str
-
-
-class AuthData(BaseModel):
-    username: str
-    password: str
-
-
-class UserCredits(BaseModel):
-    username: str
-    hashed_password: str
-
-
-class TokenData(BaseModel):
-    username: str
-
-
-class Token(BaseModel):
-    access_token: str
-    token_type: str
-
-
-# Support functions
-
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
-
-def hash_password(password: str) -> str:
-    return pwd_context.hash(password)
-
-
-def generate_token(data: TokenData) -> str:
-    return jwt.encode(data.dict(), SECRET_KEY, algorithm=ALGORITHM)
-
-
-def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return pwd_context.verify(plain_password, hashed_password)
-
-
-def authenticate_user(database: dict, username: str, password: str) -> Union[UserCredits, None]:
-    if username not in database:
-        return None
-
-    raw_data = database[username]
-    user_credits = UserCredits(username=raw_data["username"], hashed_password=raw_data["hashed_password"])
-    verify_result = verify_password(password, user_credits.hashed_password)
-
-    if not verify_result:
-        return None
-
-    return user_credits
-
-
-def decode_token(token: str) -> TokenData:
-    payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-    token_data = TokenData(username=payload["username"])
-    return token_data
-
-
-# App
-
-service = RPCService("auth_service", "amqp://guest:guest@localhost")
-db = dict()
-
-
-async def register(registration_data: Registration) -> Token:
-    user_credits = UserCredits(
-        username=registration_data.username,
-        hashed_password=hash_password(registration_data.password))
-
-    if user_credits.username in db:
-        raise ResponseError(error_type="taken", detail="Username taken")
-
-    db[user_credits.username] = user_credits.dict()
-    token_data = TokenData(username=user_credits.username)
-    token = Token(access_token=generate_token(token_data), token_type="bearer")
-
-    return token
-
-
-async def auth_user(auth_data: AuthData):
-    user_credits = authenticate_user(db, auth_data.username, auth_data.password)
-
-    if not user_credits:
-        raise ResponseError(error_type="invalid_credits", detail="Incorrect password or username")
-
-    token_data = TokenData(username=user_credits.username)
-    token = Token(access_token=generate_token(token_data), token_type="bearer")
-
-    return token
-
-
-async def verify_user(token: str) -> TokenData:
-    try:
-        token_data = decode_token(token)
-    except DecodeError:
-        raise ResponseError(error_type="invalid_credits", detail='Invalid credentials')
-
-    if token_data.username not in db:
-        raise ResponseError(error_type="invalid_credits", detail='Invalid credentials')
-
-    return token_data
-
-# Bindings
-
-service.bind("register", register)
-service.bind("generate_token", auth_user)
-service.bind("decode_token", verify_user)
+implementation = Implementation(database=db, validate_method=jwt)
+service = RpcServiceBuilder.from_contract(implementation, auth_service.Contract)
+launcher = ServiceLauncher(service)
 
 
 async def main():
-    await service.run()
-    await asyncio.Future()
+    await db.connect()
+    await launcher.start(settings.amqp_dsn)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     asyncio.run(main())

--- a/services/auth_service/methods.py
+++ b/services/auth_service/methods.py
@@ -1,0 +1,41 @@
+from contracts import auth_service
+from services.auth_service import domain, infrastructure
+from services.auth_service.domain import adapters
+
+
+class Implementation(auth_service.Contract):
+    def __init__(self, database: adapters.CredentialsStorage, validate_method: adapters.ValidateMethod):
+        self._database = database
+        self._validate_method = validate_method
+
+    async def register_user(self, login: str, password: str) -> auth_service.Token:
+        try:
+            credentials = domain.CredentialsModel(login=login, password=password)
+            await domain.RegisterUser(self._database)(credentials)
+
+        except domain.adapters.AlreadyRegistered:
+            raise auth_service.UsernameTaken(username=login)
+
+        auth_data = infrastructure.Authorize(login=login, password=password)
+        token: infrastructure.Token = await domain.AuthorizeUser(self._validate_method)(auth_data)
+
+        return auth_service.Token(access_token=token.token, token_type='bearer')
+
+    async def generate_access_token(self, login: str, password: str) -> auth_service.Token:
+        try:
+            auth_data = infrastructure.Authorize(login=login, password=password)
+            token: infrastructure.Token = await domain.AuthorizeUser(self._validate_method)(auth_data)
+
+        except domain.adapters.InvalidAuthorizationData:
+            raise auth_service.InvalidCredentials()
+
+        return auth_service.Token(access_token=token.token, token_type='bearer')
+
+    async def authenticate(self, token: str) -> auth_service.TokenData:
+        try:
+            credentials = await domain.AuthenticateUser(self._validate_method)(infrastructure.Token(token=token))
+
+        except domain.adapters.InvalidAuthenticationData:
+            raise auth_service.InvalidToken(token=token)
+
+        return auth_service.TokenData(username=credentials.login)

--- a/services/gateway_service/dependencies.py
+++ b/services/gateway_service/dependencies.py
@@ -1,0 +1,36 @@
+from fastapi import Depends, HTTPException
+from fastapi.security import OAuth2PasswordBearer
+from starlette import status
+
+from contracts import account_service, auth_service
+from rpc_service import RpcClientBuilder
+from services.gateway_service import schemas
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl='/auth/login')
+
+
+class AuthDependency:
+    def __init__(self):
+        self._accounts_service_client = RpcClientBuilder.from_contract(account_service.Contract)
+        self._auth_service_client = RpcClientBuilder.from_contract(auth_service.Contract)
+        self._connected = False
+
+    async def _connect_clients(self):
+        await self._accounts_service_client.connect('amqp://guest:guest@localhost')
+        await self._auth_service_client.connect('amqp://guest:guest@localhost')
+
+    async def __call__(self, token: str = Depends(oauth2_scheme)) -> schemas.AccountInfo:
+        if not self._connected:
+            await self._connect_clients()
+            self._connected = True
+
+        try:
+            decoded = await self._auth_service_client.authenticate(token=token)
+            print(decoded)
+            account = await self._accounts_service_client.get_account(username=decoded.username)
+            return schemas.AccountInfo(username=account.username, rating=account.rating)
+        except (auth_service.InvalidToken, account_service.NotExists):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid token')
+
+
+get_current_user = AuthDependency()

--- a/services/gateway_service/main.py
+++ b/services/gateway_service/main.py
@@ -1,0 +1,15 @@
+import uvicorn
+from fastapi import FastAPI
+from services.gateway_service import routers
+
+
+app = FastAPI()
+
+app.include_router(routers.users_router, prefix='/users')
+app.include_router(routers.auth_router, prefix='/auth')
+app.include_router(routers.private_room_router, prefix='/room')
+app.include_router(routers.session_router, prefix='/session')
+app.include_router(routers.searcher_router, prefix='/search')
+
+if __name__ == '__main__':
+    uvicorn.run("main:app", port=5000, log_level="info")

--- a/services/gateway_service/routers/__init__.py
+++ b/services/gateway_service/routers/__init__.py
@@ -1,0 +1,14 @@
+from .auth import auth_router
+from .users import users_router
+from .private_room import private_room_router
+from .session import session_router
+from .searcher import searcher_router
+
+
+__all__ = [
+    'auth_router',
+    'users_router',
+    'private_room_router',
+    'session_router',
+    'searcher_router'
+]

--- a/services/gateway_service/routers/auth.py
+++ b/services/gateway_service/routers/auth.py
@@ -1,0 +1,45 @@
+from fastapi import HTTPException
+
+from fastapi import APIRouter, Depends
+from fastapi.security import OAuth2PasswordRequestForm
+from starlette import status
+
+from contracts import auth_service, account_service
+from rpc_service import RpcClientBuilder
+from services.gateway_service import schemas
+
+auth_router = APIRouter()
+auth_service_client = RpcClientBuilder.from_contract(auth_service.Contract)
+account_service_client = RpcClientBuilder.from_contract(account_service.Contract)
+
+
+@auth_router.on_event('startup')
+async def open_connections():
+    await auth_service_client.connect('amqp://guest:guest@localhost')
+    await account_service_client.connect('amqp://guest:guest@localhost')
+
+
+@auth_router.on_event('shutdown')
+async def close_connection():
+    await auth_service_client.close()
+    await account_service_client.close()
+
+
+@auth_router.post('/register')
+async def register_user(credentials: schemas.Registration) -> schemas.Token:
+    try:
+        token = await auth_service_client.register_user(login=credentials.username, password=credentials.password)
+        await account_service_client.create_account(username=credentials.username)
+    except auth_service.UsernameTaken:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Username taken')
+
+    return schemas.Token(**token.dict())
+
+
+@auth_router.post('/login')
+async def authorize_user(credentials: OAuth2PasswordRequestForm = Depends()) -> schemas.Token:
+    try:
+        token = await auth_service_client.generate_access_token(login=credentials.username, password=credentials.password)
+        return schemas.Token(**token.dict())
+    except auth_service.InvalidCredentials:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Wrong password or username')

--- a/services/gateway_service/routers/private_room.py
+++ b/services/gateway_service/routers/private_room.py
@@ -1,0 +1,87 @@
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.websockets import WebSocket
+from starlette import status
+
+from amqp_events import AmqpEventListener
+from amqp_events.utils import wait_for_publish
+from contracts import private_room_service
+from rpc_service import RpcClientBuilder
+from services.gateway_service import schemas
+from services.gateway_service.dependencies import get_current_user
+
+private_room_router = APIRouter()
+private_room_listener = AmqpEventListener('private_room_service.events')
+private_room_service_client = RpcClientBuilder.from_contract(private_room_service.Contract)
+
+
+@private_room_router.on_event('startup')
+async def open_connections():
+    await private_room_listener.connect('amqp://guest:guest@localhost')
+    await private_room_service_client.connect('amqp://guest:guest@localhost')
+
+
+@private_room_router.on_event('shutdown')
+async def close_connections():
+    await private_room_listener.close()
+    await private_room_service_client.close()
+
+
+@private_room_router.post('/create')
+async def create_private_room(current_user: schemas.AccountInfo = Depends(get_current_user)) -> schemas.PrivateRoomInfo:
+    room = await private_room_service_client.create(player_name=current_user.username)
+    return schemas.PrivateRoomInfo(connection_key=room.connection_key)
+
+
+@private_room_router.post('/connect')
+async def connect_to_private_room(
+        connection_key: str,
+        current_user: schemas.AccountInfo = Depends(get_current_user)):
+    try:
+        await private_room_service_client.connect_room(
+            player_name=current_user.username,
+            connection_key=connection_key)
+
+    except private_room_service.RoomNotFound as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+    return 'Success'
+
+
+@private_room_router.post('/close')
+async def close_private_room(
+        connection_key: str,
+        current_user: schemas.AccountInfo = Depends(get_current_user)):
+    try:
+        await private_room_service_client.disconnect_room(
+            player_name=current_user.username,
+            connection_key=connection_key)
+
+    except private_room_service.RoomNotFound as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except private_room_service.PlayerNotConnected as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    return 'Success'
+
+
+@private_room_router.websocket('/wait')
+async def wait_for_opponent_connect(token: str, connection_key: str, websocket: WebSocket):
+    await websocket.accept()
+
+    try:
+        await get_current_user(token)
+    except HTTPException as e:
+        await websocket.send_text(e.detail)
+        await websocket.close()
+        return
+
+    event_message = await wait_for_publish(
+        lambda msg: (msg.get('event_type'), msg.get('connection_key')) == ('OPPONENT_CONNECTED', connection_key),
+        private_room_listener
+    )
+
+    await websocket.send_json({
+        'event_type': event_message['event_type'],
+        'session_id': event_message['session_id']
+    })
+    await websocket.close()

--- a/services/gateway_service/routers/searcher.py
+++ b/services/gateway_service/routers/searcher.py
@@ -1,0 +1,77 @@
+from fastapi import APIRouter, Depends, HTTPException
+from starlette import status
+from starlette.websockets import WebSocket
+
+from amqp_events import AmqpEventListener
+from amqp_events.utils import wait_for_publish
+from contracts import searcher_service
+from rpc_service import RpcClientBuilder
+from services.gateway_service import schemas
+from services.gateway_service.dependencies import get_current_user
+
+searcher_router = APIRouter()
+searcher_listener = AmqpEventListener('searcher_service.events')
+searcher_service_client = RpcClientBuilder.from_contract(searcher_service.Contract)
+
+
+@searcher_router.on_event('shutdown')
+async def close_connections():
+    await searcher_listener.close()
+    await searcher_service_client.close()
+
+
+@searcher_router.on_event('startup')
+async def open_connections():
+    await searcher_listener.connect('amqp://guest:guest@localhost')
+    await searcher_service_client.connect('amqp://guest:guest@localhost')
+
+
+@searcher_router.post('/start')
+async def start_search(
+        parameters: schemas.SearchParameters,
+        current_user: schemas.AccountInfo = Depends(get_current_user)):
+    caller = searcher_service.CallerInfo(name=current_user.username, rating=current_user.rating)
+    params = searcher_service.SearchParameters(**parameters.dict())
+
+    try:
+        await searcher_service_client.start_search(parameters=params, caller=caller)
+    except searcher_service.SearchAlreadyStarted as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    return 'Success'
+
+
+@searcher_router.post('/cancel')
+async def end_search(current_user: schemas.AccountInfo = Depends(get_current_user)):
+    caller = searcher_service.CallerInfo(name=current_user.username, rating=current_user.rating)
+
+    try:
+        await searcher_service_client.cancel_search(caller=caller)
+    except searcher_service.SearchNotStarted as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    return 'Success'
+
+
+@searcher_router.websocket('/wait')
+async def wait_for_opponent_connect(token: str, websocket: WebSocket):
+    await websocket.accept()
+
+    try:
+        user = await get_current_user(token)
+    except HTTPException as e:
+        await websocket.send_text(e.detail)
+        await websocket.close()
+        return
+
+    event_message = await wait_for_publish(
+        lambda msg: (msg.get('event_type'), msg.get('caller')) == ('FOUND_OPPONENT', user.username),
+        searcher_listener
+    )
+
+    await websocket.send_json({
+        'event_type': event_message['event_type'],
+        'session_id': event_message['session_id']
+    })
+
+    await websocket.close()

--- a/services/gateway_service/routers/session.py
+++ b/services/gateway_service/routers/session.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, HTTPException
+from fastapi.websockets import WebSocket
+
+from amqp_events import AmqpEventListener
+from contracts import session_service
+from rpc_service import RpcClientBuilder
+from services.gateway_service.dependencies import get_current_user
+from services.gateway_service.websocket_formatters import ConnectionContext, WebSocketCommandReceiver, WebSocketSessionEventObserver
+
+
+session_router = APIRouter()
+session_service_client = RpcClientBuilder.from_contract(session_service.Contract)
+session_events_listener = AmqpEventListener('session_service.sessions.events')
+
+
+@session_router.on_event('startup')
+async def open_connections():
+    await session_service_client.connect('amqp://guest:guest@localhost')
+    await session_events_listener.connect('amqp://guest:guest@localhost')
+
+
+@session_router.on_event('shutdown')
+async def close_connections():
+    await session_service_client.close()
+    await session_events_listener.close()
+
+
+@session_router.websocket('/connect')
+async def connect_to_game_session(websocket: WebSocket, token: str, session_id: int):
+    await websocket.accept()
+
+    try:
+        user = await get_current_user(token)
+    except HTTPException as e:
+        await websocket.send_text(str(e))
+        await websocket.close()
+        return
+
+    try:
+        await session_service_client.connect_to_session(player_name=user.username, session_id=session_id)
+    except (session_service.NotExists, session_service.AccessDenied) as e:
+        await websocket.send_text(str(e))
+        await websocket.close()
+        return
+
+    context = ConnectionContext(websocket=websocket, player_name=user.username, session_id=session_id)
+    sender = WebSocketCommandReceiver(context, session_service_client)
+    observer = WebSocketSessionEventObserver(context)
+
+    session_events_listener.attach(observer)
+    await sender.start_listen()
+    session_events_listener.detach(observer)
+    await websocket.close()

--- a/services/gateway_service/routers/users.py
+++ b/services/gateway_service/routers/users.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, HTTPException, Depends
+from starlette import status
+
+from services.gateway_service.dependencies import get_current_user
+from services.gateway_service.schemas import AccountInfo
+from rpc_service import RpcClientBuilder
+from contracts import account_service
+
+
+users_router = APIRouter()
+accounts_service_client = RpcClientBuilder.from_contract(account_service.Contract)
+
+
+@users_router.on_event('startup')
+async def open_connections():
+    await accounts_service_client.connect('amqp://guest:guest@localhost')
+
+
+@users_router.on_event('shutdown')
+async def close_connections():
+    await accounts_service_client.close()
+
+
+@users_router.get('/me')
+async def get_current_user_account_info(current_user: AccountInfo = Depends(get_current_user)):
+    return current_user
+
+
+@users_router.get('/{username}')
+async def get_user_b_username(username: str) -> AccountInfo:
+    try:
+        account = await accounts_service_client.get_account(username=username)
+        return AccountInfo(username=account.username, rating=account.rating)
+    except account_service.NotExists as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/services/gateway_service/schemas.py
+++ b/services/gateway_service/schemas.py
@@ -1,0 +1,25 @@
+import pydantic
+
+
+class AccountInfo(pydantic.BaseModel):
+    username: str
+    rating: int
+
+
+class Registration(pydantic.BaseModel):
+    username: str
+    password: str
+
+
+class Token(pydantic.BaseModel):
+    access_token: str
+    token_type: str
+
+
+class PrivateRoomInfo(pydantic.BaseModel):
+    connection_key: str
+
+
+class SearchParameters(pydantic.BaseModel):
+    min_rating: int
+    max_rating: int

--- a/services/gateway_service/websocket_formatters.py
+++ b/services/gateway_service/websocket_formatters.py
@@ -1,0 +1,53 @@
+import asyncio
+from dataclasses import dataclass
+from starlette.websockets import WebSocket, WebSocketDisconnect
+from contracts import session_service
+
+
+@dataclass(frozen=True)
+class ConnectionContext:
+    websocket: WebSocket
+    player_name: str
+    session_id: int
+
+
+class WebSocketCommandReceiver:
+    _client: session_service.Contract
+    _context: ConnectionContext
+
+    def __init__(self, context: ConnectionContext, client: session_service.Contract):
+        self._client = client
+        self._context = context
+        self._disconnect_future = asyncio.Future()
+
+    async def _send_command(self, command: dict):
+        try:
+            await self._client.execute_command(
+                session_id=self._context.session_id,
+                player_name=self._context.player_name,
+                command=command)
+        except session_service.ExecuteCommandError as e:
+            await self._context.websocket.send_text(str(e))
+
+    async def start_listen(self):
+        while True:
+            try:
+                command = await self._context.websocket.receive_json()
+                await self._send_command(command)
+            except WebSocketDisconnect:
+                break
+
+
+class WebSocketSessionEventObserver:
+    _context: ConnectionContext
+
+    def __init__(self, context: ConnectionContext):
+        self._context = context
+
+    def _validate_message(self, message: dict) -> bool:
+        return message.get('session_id') == self._context.session_id
+
+    async def __call__(self, message: dict):
+        print(f'Got message: {message}')
+        if self._validate_message(message):
+            await self._context.websocket.send_json(message)

--- a/services/private_room_service/domain/__init__.py
+++ b/services/private_room_service/domain/__init__.py
@@ -1,0 +1,8 @@
+from .usecases import CreatePrivateRoom, ConnectToPrivateRoom, DisconnectFromPrivateRoom
+
+
+__all__ = [
+    'CreatePrivateRoom',
+    'ConnectToPrivateRoom',
+    'DisconnectFromPrivateRoom'
+]

--- a/services/private_room_service/domain/adapters/__init__.py
+++ b/services/private_room_service/domain/adapters/__init__.py
@@ -1,0 +1,13 @@
+from .session_service import SessionServiceAdapter, Session
+from .storage import PrivateRoomStorage, NotExists, AlreadyExists
+from .room_builder import PrivateRoomBuilder
+
+
+__all__ = [
+    'SessionServiceAdapter',
+    'PrivateRoomStorage',
+    'PrivateRoomBuilder',
+    'Session',
+    'NotExists',
+    'AlreadyExists'
+]

--- a/services/private_room_service/domain/adapters/room_builder.py
+++ b/services/private_room_service/domain/adapters/room_builder.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+from .. import models
+
+
+class PrivateRoomBuilder(ABC):
+    """Интерфейс для фабрики приватных комнат"""
+
+    @abstractmethod
+    async def generate_room(self) -> models.PrivateRoom:
+        """
+        Генерирует пустую приватную комнату
+
+        :return: сгенерированная комната
+        """
+        raise NotImplementedError()

--- a/services/private_room_service/domain/adapters/session_service.py
+++ b/services/private_room_service/domain/adapters/session_service.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Iterable, NewType
+from .. import models
+
+
+SessionId = NewType('SessionId', int)
+
+
+@dataclass(frozen=True)
+class Session:
+    """
+    Value Object созданной сессии
+
+    Arguments:
+        id - идентификатор созданной сессии
+    """
+
+    id: SessionId
+
+
+class SessionServiceAdapter(ABC):
+    """
+    Адаптер к сервису игровых сессий
+    """
+
+    @abstractmethod
+    async def create_session(self, players: Iterable[models.Player]) -> Session:
+        """
+        Посылает запрос сервису на создание игровой сессии для игроков
+
+        :param players: игроки, для которых создается игровая сессия
+        :return: созданная сессия
+        """
+        raise NotImplementedError()

--- a/services/private_room_service/domain/adapters/storage.py
+++ b/services/private_room_service/domain/adapters/storage.py
@@ -1,0 +1,86 @@
+from abc import abstractmethod, ABC
+from .. import models
+
+
+class NotExists(Exception):
+    """
+    Исключение, вызываемое хранилищем приватных комнат, в момент,
+    когда требуемой приватной комнаты не существует
+
+    Arguments:
+        connection_key - ключ подключения, по которому производился поиск
+    """
+
+    connection_key: models.ConnectionKey
+    __message: str = 'Private room with connection key {connection_key!r} not exists'
+
+    def __init__(self, connection_key: models.ConnectionKey):
+        super().__init__(self.__message.format(connection_key=connection_key))
+        self.connection_key = connection_key
+
+
+class AlreadyExists(Exception):
+    """
+    Исключение, вызываемое хранилищем приватных комнат, в момент, когда
+    комната с текущим ключом подключения уже существует
+
+    Argument:
+        connection_key - ключ подключения, по которому создавалась комната
+    """
+
+    connection_key: models.ConnectionKey
+    __message: str = 'Private room with connection key {connection_key!r} already exists'
+
+    def __init__(self, connection_key: models.ConnectionKey):
+        super().__init__(self.__message.format(connection_key=connection_key))
+        self.connection_key = connection_key
+
+
+class PrivateRoomStorage(ABC):
+    """
+    Адаптер к хранилищу приватных комнат.
+    """
+
+    @abstractmethod
+    async def create_room(self, connection_key: models.ConnectionKey) -> models.PrivateRoom:
+        """
+        Создать новую приватную комнату с указанным ключом подключения
+
+        :param connection_key:
+        :return: созданная приватная комната
+        :raise AlreadyExists: приватная комната с таким ключом подключения существует
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def remove_room(self, connection_key: models.ConnectionKey):
+        """
+        Удаляет приватную комнату с указанным ключом подключения
+
+        :param connection_key: ключ подключения, соответствующий удаляемой комнате
+        :raise NotExists: комната с таким ключом подключения не существует
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def update_room(self, updated_data: models.PrivateRoom) -> models.PrivateRoom:
+        """
+        Обновляет информацию о приватной комнате
+
+        :param updated_data: новая информация о приватной комнате
+        :return: обновленная информация из хранилища
+        :raise NotExists: приватная комната не была до этого создана
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def get_room(self, connection_key: models.ConnectionKey) -> models.PrivateRoom:
+        """
+        Возвращает информацию о приватной комнате, ключ
+        подключения которой соответствует переданному
+
+        :param connection_key: ключ подключения, по которому идет поиск комнаты
+        :return: найденная информация о приватной комнате
+        :raise NotExists: приватная комната не была до этого создана
+        """
+        raise NotImplementedError()

--- a/services/private_room_service/domain/events.py
+++ b/services/private_room_service/domain/events.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from aievents import Events
+from . import models, adapters
+
+
+@dataclass(frozen=True)
+class OnPrivateRoomFullMessage:
+    """
+    Сообщение, посылаемое всем подписчикам на событие 'on_private_room_full'
+
+    Arguments:
+        room - комната, которая заполнилась
+        created_session - созданная игровая сессия для игроков
+    """
+
+    room: models.PrivateRoom
+    created_session: adapters.Session
+
+
+class PrivateRoomEvents(Events):
+    """
+    События, происходящие во время выполнения в бизнес части
+
+    Events:
+        on_private_room_full - приватная комната заполнилась
+    """
+
+    __events__ = ('on_private_room_full', )
+
+
+private_room_events = PrivateRoomEvents()
+print('Initialized events')

--- a/services/private_room_service/domain/models.py
+++ b/services/private_room_service/domain/models.py
@@ -1,0 +1,115 @@
+from dataclasses import dataclass
+from typing import List, NewType, Tuple
+
+ConnectionKey = NewType('ConnectionKey', str)
+
+
+class PrivateRoomFull(Exception):
+    """
+    Исключение, вызываемое моделью приватной комнаты в момент, когда
+    происходит попытка добавить игрока в уже заполненную комнату
+
+    Arguments:
+        player - игрок, которого пытались добавить
+        room - заполненная комната, в которую пытались добавить
+    """
+
+    player: 'Player'
+    room: 'PrivateRoom'
+    __message: str = 'Enable to add player {player!r}. Private room {room!r} is full'
+
+    def __init__(self, player: 'Player', room: 'PrivateRoom'):
+        super().__init__(self.__message.format(player=player, room=room))
+        self.player = player
+        self.room = room
+
+
+class NotConnected(Exception):
+    """
+    Исключение, вызываемое моделью приватной комнаты в момент, когда
+    происходит попытка отключить игрока от комнаты, к которой он не
+    был подключен
+
+    Arguments:
+        player - игрок, которого пытались отключить
+        room - комната, к которой не подключен игрок
+    """
+
+    player: 'Player'
+    room: 'PrivateRoom'
+    __message: str = 'Enable to disconnect player {player!r}. Player not connected to room {room!r}'
+
+    def __init__(self, player: 'Player', room: 'PrivateRoom'):
+        super().__init__(self.__message.format(player=player, room=room))
+        self.player = player
+        self.room = room
+
+
+@dataclass(frozen=True)
+class Player:
+    """
+    Бизнес модель игрока, подключенного к приватной комнате
+
+    Arguments:
+        name - имя игрока
+    """
+
+    name: str
+
+
+@dataclass
+class PrivateRoom:
+    """
+    Бизнес модель приватной комнаты
+    """
+
+    _players: List[Player]
+    _connection_key: ConnectionKey
+    _max_players_amount: int = 2
+
+    def add_player(self, player: Player):
+        """
+        Подключает игрока к приватной комнате
+
+        :param player: игрок, которого добавляем
+        :raise PrivateRoomFull: текущая приватная комната уже заполнена
+        """
+
+        if player in self._players:
+            return
+
+        if self.is_full():
+            raise PrivateRoomFull(player=player, room=self)
+
+        self._players.append(player)
+
+    def remove_player(self, player: Player):
+        """
+        Отключает игрока от приватной комнаты
+
+        :param player: игрок, которого удаляем
+        :raise NotConnected: если отключаемый игрок не был до этого подключен
+        """
+
+        if player not in self._players:
+            raise NotConnected(player=player, room=self)
+
+        self._players.remove(player)
+
+    @property
+    def players(self) -> Tuple[Player]:
+        """Игроки, подключенные к приватной комнате"""
+        return tuple(self._players)
+
+    @property
+    def connection_key(self) -> ConnectionKey:
+        """Ключ для подключения к комнате"""
+        return self._connection_key
+
+    def is_full(self) -> bool:
+        """Текущая приватная комната заполнена? """
+        return len(self._players) >= self._max_players_amount
+
+    def is_empty(self) -> bool:
+        """Текущая приватная комната пустая?"""
+        return len(self._players) == 0

--- a/services/private_room_service/domain/usecases.py
+++ b/services/private_room_service/domain/usecases.py
@@ -1,0 +1,63 @@
+from . import adapters, models, events
+
+
+class CreatePrivateRoom:
+    """Создает приватную комнату"""
+
+    _storage: adapters.PrivateRoomStorage
+    _builder: adapters.PrivateRoomBuilder
+
+    def __init__(self, storage: adapters.PrivateRoomStorage, builder: adapters.PrivateRoomBuilder):
+        self._storage = storage
+        self._builder = builder
+
+    async def __call__(self) -> models.PrivateRoom:
+        room = await self._builder.generate_room()
+        await self._storage.create_room(room.connection_key)
+        await self._storage.update_room(room)
+        return room
+
+
+class DisconnectFromPrivateRoom:
+    """
+    Отключает игрока от приватной комнаты. Если все игроки отключились от приватной
+    комнаты, она удаляется из хранилища
+    """
+
+    _storage: adapters.PrivateRoomStorage
+
+    def __init__(self, storage: adapters.PrivateRoomStorage):
+        self._storage = storage
+
+    async def __call__(self, connection_key: models.ConnectionKey, player: models.Player):
+        room = await self._storage.get_room(connection_key)
+        room.remove_player(player=player)
+        await self._storage.update_room(room)
+
+        if room.is_empty():
+            await self._storage.remove_room(room.connection_key)
+
+
+class ConnectToPrivateRoom:
+    """
+    Подключает игрока к приватной комнате.
+    В случае, если комната заполнилась, посылается запрос сервису сессий на
+    создание игровой сессии и поднимается событие 'on_private_room_full'
+    """
+
+    _storage: adapters.PrivateRoomStorage
+    _adapter: adapters.SessionServiceAdapter
+
+    def __init__(self, storage: adapters.PrivateRoomStorage, adapter: adapters.SessionServiceAdapter):
+        self._storage = storage
+        self._adapter = adapter
+
+    async def __call__(self, connection_key: models.ConnectionKey, player: models.Player):
+        room = await self._storage.get_room(connection_key)
+        room.add_player(player)
+        await self._storage.update_room(room)
+
+        if room.is_full():
+            session = await self._adapter.create_session(room.players)
+            message = events.OnPrivateRoomFullMessage(room=room, created_session=session)
+            await events.private_room_events.on_private_room_full(message)

--- a/services/private_room_service/event_handlers.py
+++ b/services/private_room_service/event_handlers.py
@@ -1,0 +1,19 @@
+from amqp_events import AmqpEventPublisher
+from .domain.events import private_room_events, OnPrivateRoomFullMessage
+
+
+amqp_publisher = AmqpEventPublisher(event_name='private_room_service.events')
+
+
+async def private_room_full_publisher(message: OnPrivateRoomFullMessage):
+    print(f'[Event] Private room {message.room.connection_key!r} full!')
+
+    await amqp_publisher.notify({
+        'event_type': 'OPPONENT_CONNECTED',
+        'connection_key': message.room.connection_key,
+        'session_id': message.created_session.id
+    })
+
+
+def bind_handlers():
+    private_room_events.on_private_room_full += private_room_full_publisher

--- a/services/private_room_service/infrastructure/__init__.py
+++ b/services/private_room_service/infrastructure/__init__.py
@@ -1,0 +1,10 @@
+from .room_builder import DefaultRoomBuilder
+from .session_service import SessionServiceClient
+from .storage import DefaultStorage
+
+
+__all__ = [
+    'DefaultStorage',
+    'DefaultRoomBuilder',
+    'SessionServiceClient'
+]

--- a/services/private_room_service/infrastructure/room_builder.py
+++ b/services/private_room_service/infrastructure/room_builder.py
@@ -1,0 +1,32 @@
+import random
+from ..domain import adapters, models
+
+
+def _generate_connection_key() -> models.ConnectionKey:
+    alph = 'ABCDEFGHIJKLMNOPQRCT'
+    parts = []
+
+    for _ in range(3):
+        parts.append(''.join([random.choice(alph) for _ in range(3)]))
+
+    return '-'.join(parts)
+
+
+class DefaultRoomBuilder(adapters.PrivateRoomBuilder):
+    _storage: adapters.PrivateRoomStorage
+
+    def __init__(self, storage: adapters.PrivateRoomStorage):
+        self._storage = storage
+
+    async def generate_room(self) -> models.PrivateRoom:
+        connection_key = _generate_connection_key()
+
+        while True:
+            try:
+                await self._storage.get_room(connection_key)
+            except adapters.NotExists:
+                break
+
+            connection_key = _generate_connection_key()
+
+        return models.PrivateRoom(_players=[], _connection_key=connection_key)

--- a/services/private_room_service/infrastructure/session_service.py
+++ b/services/private_room_service/infrastructure/session_service.py
@@ -1,0 +1,21 @@
+from typing import Iterable
+
+from contracts import session_service
+from rpc_service import RpcClientBuilder
+from ..domain import adapters, models
+
+
+class SessionServiceClient(adapters.SessionServiceAdapter):
+    def __init__(self):
+        self._client = RpcClientBuilder.from_contract(session_service.Contract)
+
+    async def create_session(self, players: Iterable[models.Player]) -> adapters.Session:
+        first_player, second_player = map(lambda player: player.name, players)
+        response = await self._client.create_session(first_player=first_player, second_player=second_player)
+        return adapters.Session(id=response.session_id)
+
+    async def connect(self, credentials: str):
+        await self._client.connect(credentials)
+
+    async def close(self):
+        await self._client.close()

--- a/services/private_room_service/infrastructure/storage.py
+++ b/services/private_room_service/infrastructure/storage.py
@@ -1,0 +1,90 @@
+from tortoise import Model, fields, Tortoise
+from tortoise.exceptions import NoValuesFetched
+
+from services.private_room_service.domain import adapters, models
+from settings import settings
+
+
+class PrivateRoomDBModel(Model):
+    id = fields.IntField(pk=True)
+    connection_key = fields.CharField(max_length=50, unique=True)
+    connected_players: fields.ReverseRelation['PlayerDBModel']
+
+
+class PlayerDBModel(Model):
+    name = fields.TextField()
+    connected_room: fields.ForeignKeyRelation[PrivateRoomDBModel] = fields.ForeignKeyField(
+        'models.PrivateRoomDBModel', related_name='connected_players'
+    )
+
+
+class DefaultStorage(adapters.PrivateRoomStorage):
+    async def connect(self):
+        await Tortoise.init(
+            db_url=settings.postgres_dsn,
+            modules={'models': ['services.private_room_service.infrastructure.storage']}
+        )
+
+        await Tortoise.generate_schemas()
+
+    async def create_room(self, connection_key: models.ConnectionKey) -> models.PrivateRoom:
+        record = await PrivateRoomDBModel.filter(connection_key=connection_key).first()
+
+        if record is not None:
+            raise adapters.AlreadyExists(connection_key=connection_key)
+
+        created_record = await PrivateRoomDBModel.create(connection_key=connection_key)
+        return models.PrivateRoom(_connection_key=created_record.connection_key, _players=[])
+
+    async def remove_room(self, connection_key: models.ConnectionKey):
+        record = await PrivateRoomDBModel.filter(connection_key=connection_key).first()
+
+        if record is None:
+            raise adapters.NotExists(connection_key=connection_key)
+
+        await record.delete()
+
+    async def update_room(self, updated_data: models.PrivateRoom) -> models.PrivateRoom:
+        record = await PrivateRoomDBModel.filter(connection_key=updated_data.connection_key).first()
+
+        if record is None:
+            raise adapters.NotExists(connection_key=updated_data.connection_key)
+
+        record.connection_key = updated_data.connection_key
+
+        for connected_player in updated_data.players:
+            player = await PlayerDBModel.filter(name=connected_player.name).first()
+
+            if player is None:
+                player = await PlayerDBModel.create(name=connected_player.name, connected_room=record)
+
+            player.connected_room = record
+            await player.save()
+
+        await record.save()
+
+        try:
+            connected_players = await record.connected_players.all()
+        except NoValuesFetched:
+            connected_players = []
+
+        return models.PrivateRoom(
+            _connection_key=record.connection_key,
+            _players=[models.Player(name=player.name) for player in connected_players]
+        )
+
+    async def get_room(self, connection_key: models.ConnectionKey) -> models.PrivateRoom:
+        record = await PrivateRoomDBModel.filter(connection_key=connection_key).first()
+
+        if record is None:
+            raise adapters.NotExists(connection_key=connection_key)
+
+        try:
+            connected_players = await record.connected_players.all()
+        except NoValuesFetched:
+            connected_players = []
+
+        return models.PrivateRoom(
+            _connection_key=record.connection_key,
+            _players=[models.Player(name=player.name) for player in connected_players]
+        )

--- a/services/private_room_service/main.py
+++ b/services/private_room_service/main.py
@@ -1,0 +1,36 @@
+import asyncio
+from contracts import private_room_service
+from rpc_service import RpcServiceBuilder
+from rpc_service.utils import ServiceLauncher
+from services.private_room_service import infrastructure, event_handlers
+from services.private_room_service.methods import Implementation
+from settings import settings
+
+client = infrastructure.SessionServiceClient()
+db = infrastructure.DefaultStorage()
+builder = infrastructure.DefaultRoomBuilder(db)
+
+implementation = Implementation(database=db, builder=builder, client=client)
+service = RpcServiceBuilder.from_contract(implementation, private_room_service.Contract)
+launcher = ServiceLauncher(service=service)
+loop = asyncio.get_event_loop()
+
+
+async def open_connections():
+    await db.connect()
+    await client.connect(settings.amqp_dsn)
+    event_handlers.bind_handlers()
+    await event_handlers.amqp_publisher.connect(settings.amqp_dsn)
+    await launcher.start(settings.amqp_dsn)
+
+
+async def close_connections():
+    await client.close()
+    await event_handlers.amqp_publisher.close()
+
+
+if __name__ == '__main__':
+    try:
+        asyncio.run(open_connections())
+    except KeyboardInterrupt:
+        asyncio.run(close_connections())

--- a/services/private_room_service/methods.py
+++ b/services/private_room_service/methods.py
@@ -1,0 +1,38 @@
+from contracts import private_room_service
+from services.private_room_service import domain
+from services.private_room_service.domain import adapters, models
+
+
+class Implementation(private_room_service.Contract):
+    def __init__(self,
+                 database: adapters.PrivateRoomStorage,
+                 client: adapters.SessionServiceAdapter,
+                 builder: adapters.PrivateRoomBuilder
+    ):
+        self._database = database
+        self._client = client
+        self._builder = builder
+
+    async def create(self, player_name: str) -> private_room_service.PrivateRoomInfo:
+        room = await domain.CreatePrivateRoom(self._database, self._builder)()
+        await domain.ConnectToPrivateRoom(self._database, self._client)(room.connection_key, models.Player(player_name))
+        return private_room_service.PrivateRoomInfo(connection_key=room.connection_key)
+
+    async def connect_room(self, player_name: str, connection_key: str):
+        try:
+            await domain.ConnectToPrivateRoom(self._database, self._client)(connection_key, models.Player(player_name))
+
+        except adapters.NotExists:
+            raise private_room_service.RoomNotFound(connection_key=connection_key)
+
+    async def disconnect_room(self, player_name: str, connection_key: str):
+        try:
+            await domain.DisconnectFromPrivateRoom(self._database)(
+                connection_key=connection_key,
+                player=models.Player(player_name))
+
+        except adapters.NotExists:
+            raise private_room_service.RoomNotFound(connection_key=connection_key)
+
+        except models.NotConnected:
+            raise private_room_service.PlayerNotConnected(connection_key=connection_key, player_name=player_name)

--- a/services/searcher_service/domain/__init__.py
+++ b/services/searcher_service/domain/__init__.py
@@ -1,0 +1,7 @@
+from .usecases import StartSearch, CancelSearch
+
+
+__all__ = [
+    'StartSearch',
+    'CancelSearch'
+]

--- a/services/searcher_service/domain/adapters/__init__.py
+++ b/services/searcher_service/domain/adapters/__init__.py
@@ -1,0 +1,11 @@
+from .session_service import SessionServiceAdapter, Session
+from .storage import WaitingPlayersStorage, AlreadyExists, NotExists
+
+
+__all__ = [
+    'SessionServiceAdapter',
+    'WaitingPlayersStorage',
+    'AlreadyExists',
+    'NotExists',
+    'Session'
+]

--- a/services/searcher_service/domain/adapters/session_service.py
+++ b/services/searcher_service/domain/adapters/session_service.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Iterable, NewType
+from .. import models
+
+
+SessionId = NewType('SessionId', int)
+
+
+@dataclass(frozen=True)
+class Session:
+    """
+    Value Object созданной сессии
+
+    Arguments:
+        id - идентификатор созданной сессии
+    """
+
+    id: SessionId
+
+
+class SessionServiceAdapter(ABC):
+    """
+    Адаптер к сервису игровых сессий
+    """
+
+    @abstractmethod
+    async def create_session(self, players: Iterable[models.WaitingPlayer]) -> Session:
+        """
+        Посылает запрос сервису на создание игровой сессии для игроков
+
+        :param players: игроки, для которых создается игровая сессия
+        :return: созданная сессия
+        """
+        raise NotImplementedError()

--- a/services/searcher_service/domain/adapters/storage.py
+++ b/services/searcher_service/domain/adapters/storage.py
@@ -1,0 +1,34 @@
+from abc import ABC, abstractmethod
+from .. import models
+
+
+class AlreadyExists(Exception):
+    player: models.WaitingPlayer
+    _message: str = 'Player {player_name!r} already waiting for opponent'
+
+    def __init__(self, player: models.WaitingPlayer):
+        super().__init__(self._message.format(player_name=player.name))
+        self.player = player
+
+
+class NotExists(Exception):
+    player: models.WaitingPlayer
+    _message: str = 'Player {player_name!r} not waiting for opponent'
+
+    def __init__(self, player: models.WaitingPlayer):
+        super().__init__(self._message.format(player_name=player.name))
+        self.player = player
+
+
+class WaitingPlayersStorage(ABC):
+    @abstractmethod
+    async def add_player(self, player: models.WaitingPlayer):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def remove_player(self, player: models.WaitingPlayer):
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def find_opponent(self, player: models.WaitingPlayer) -> models.WaitingPlayer | None:
+        raise NotImplementedError()

--- a/services/searcher_service/domain/events.py
+++ b/services/searcher_service/domain/events.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from aievents import Events
+from . import adapters, models
+
+
+@dataclass(frozen=True)
+class OnFindOpponentMessage:
+    created_session: adapters.Session
+    caller: models.WaitingPlayer
+
+
+class SearcherEvents(Events):
+    __events__ = ('on_find_opponent', )
+
+
+searcher_events = SearcherEvents()
+print('Initialized events')

--- a/services/searcher_service/domain/models.py
+++ b/services/searcher_service/domain/models.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SearchParameters:
+    min_rating: int
+    max_rating: int
+
+
+@dataclass(frozen=True)
+class WaitingPlayer:
+    name: str
+    rating: int
+    parameters: SearchParameters
+
+    def check_opponent(self, opponent: "WaitingPlayer") -> bool:
+        return self.parameters.min_rating <= opponent.rating <= self.parameters.max_rating

--- a/services/searcher_service/domain/usecases.py
+++ b/services/searcher_service/domain/usecases.py
@@ -1,0 +1,36 @@
+from . import adapters, models, events
+
+
+async def _notify_about_find_opponent(caller: models.WaitingPlayer, created_session: adapters.Session):
+    message = events.OnFindOpponentMessage(caller=caller, created_session=created_session)
+    await events.searcher_events.on_find_opponent(message)
+
+
+class StartSearch:
+    _storage: adapters.WaitingPlayersStorage
+    _adapter: adapters.SessionServiceAdapter
+
+    def __init__(self, storage: adapters.WaitingPlayersStorage, adapter: adapters.SessionServiceAdapter):
+        self._storage = storage
+        self._adapter = adapter
+
+    async def __call__(self, caller: adapters.WaitingPlayersStorage):
+        await self._storage.add_player(caller)
+        opponent = await self._storage.find_opponent(caller)
+
+        if opponent is not None:
+            await self._storage.remove_player(caller)
+            await self._storage.remove_player(opponent)
+            session = await self._adapter.create_session((caller, opponent))
+            await _notify_about_find_opponent(caller, session)
+            await _notify_about_find_opponent(opponent, session)
+
+
+class CancelSearch:
+    _storage: adapters.WaitingPlayersStorage
+
+    def __init__(self, storage: adapters.WaitingPlayersStorage):
+        self._storage = storage
+
+    async def __call__(self, caller: models.WaitingPlayer):
+        await self._storage.remove_player(caller)

--- a/services/searcher_service/event_handlers.py
+++ b/services/searcher_service/event_handlers.py
@@ -1,0 +1,18 @@
+from amqp_events import AmqpEventPublisher
+from services.searcher_service.domain.events import searcher_events, OnFindOpponentMessage
+
+
+amqp_publisher = AmqpEventPublisher(event_name='searcher_service.events')
+
+
+async def on_find_opponent_publisher(message: OnFindOpponentMessage):
+    print(f'[Event] Found opponent for {message.caller.name!r}!')
+
+    await amqp_publisher.notify({
+        'event_type': 'FOUND_OPPONENT',
+        'caller': message.caller.name,
+        'session_id': message.created_session.id
+    })
+
+
+searcher_events.on_find_opponent += on_find_opponent_publisher

--- a/services/searcher_service/infrastructure/__init__.py
+++ b/services/searcher_service/infrastructure/__init__.py
@@ -1,0 +1,8 @@
+from .session_service import SessionServiceClient
+from .storage import DefaultStorage
+
+
+__all__ = [
+    'SessionServiceClient',
+    'DefaultStorage'
+]

--- a/services/searcher_service/infrastructure/session_service.py
+++ b/services/searcher_service/infrastructure/session_service.py
@@ -1,0 +1,21 @@
+from typing import Iterable
+
+from contracts import session_service
+from rpc_service import RpcClientBuilder
+from ..domain import adapters, models
+
+
+class SessionServiceClient(adapters.SessionServiceAdapter):
+    def __init__(self):
+        self._client = RpcClientBuilder.from_contract(session_service.Contract)
+
+    async def create_session(self, players: Iterable[models.WaitingPlayer]) -> adapters.Session:
+        first_player, second_player = map(lambda player: player.name, players)
+        response = await self._client.create_session(first_player=first_player, second_player=second_player)
+        return adapters.Session(id=response.session_id)
+
+    async def connect(self, credentials: str):
+        await self._client.connect(credentials)
+
+    async def close(self):
+        await self._client.close()

--- a/services/searcher_service/infrastructure/storage.py
+++ b/services/searcher_service/infrastructure/storage.py
@@ -1,0 +1,27 @@
+from typing import Dict
+from services.searcher_service.domain import adapters, models
+
+
+# TODO: Move on Redis realization
+class DefaultStorage(adapters.WaitingPlayersStorage):
+    _storage: Dict[str, models.WaitingPlayer]
+
+    def __init__(self):
+        self._storage = dict()
+
+    async def add_player(self, player: models.WaitingPlayer):
+        if player.name in self._storage:
+            raise adapters.AlreadyExists(player)
+
+        self._storage[player.name] = player
+
+    async def remove_player(self, player: models.WaitingPlayer):
+        if player.name not in self._storage:
+            raise adapters.NotExists(player)
+
+        del self._storage[player.name]
+
+    async def find_opponent(self, player: models.WaitingPlayer) -> models.WaitingPlayer | None:
+        for opponent in self._storage.values():
+            if opponent.name != player.name and player.check_opponent(opponent):
+                return opponent

--- a/services/searcher_service/main.py
+++ b/services/searcher_service/main.py
@@ -1,97 +1,31 @@
 import asyncio
-from typing import Dict, Union
-from pydantic import BaseModel
+from contracts import searcher_service
+from rpc_service import RpcServiceBuilder
+from rpc_service.utils import ServiceLauncher
+from services.searcher_service import infrastructure, event_handlers
+from services.searcher_service.methods import Implementation
+from settings import settings
 
-from amqp_events import AmqpEventPublisher
-from rpc_service.handler import ResponseError
-from rpc_service.service import RPCService
-from services.private_room_service.adapters import SessionServiceAdapter
-
-
-class SearchParameters(BaseModel):
-    min_rating: int
-    max_rating: int
-
-
-class WaitingPlayer(BaseModel):
-    name: str
-    rating: int
-    parameters: SearchParameters
+client = infrastructure.SessionServiceClient()
+db = infrastructure.DefaultStorage()
+implementation = Implementation(database=db, client=client)
+service = RpcServiceBuilder.from_contract(implementation, searcher_service.Contract)
+launcher = ServiceLauncher(service=service)
 
 
-class SuccessMessage(BaseModel):
-    message_type: str = "success"
-    detail: str = "Success"
+async def init_infrastructure():
+    await client.connect(settings.amqp_dsn)
+    await event_handlers.amqp_publisher.connect(settings.amqp_dsn)
+    await launcher.start(settings.amqp_dsn)
 
 
-db: Dict[str, WaitingPlayer] = dict()
-service = RPCService("searcher_service", "amqp://guest:guest@localhost")
-room_events_publisher = AmqpEventPublisher("searcher_service.search.events")
-session_service_adapter = None
+async def close_infrastructure():
+    await client.close()
+    await event_handlers.amqp_publisher.close()
 
 
-def find_player(parameters: SearchParameters) -> Union[None, WaitingPlayer]:
-    for waiting_player in db.values():
-        if parameters.min_rating <= waiting_player.rating <= parameters.max_rating:
-            return waiting_player
-
-
-async def notify_about_opponent_found(created_session_id: int, waiting_player_name: str):
-    await room_events_publisher.notify({
-        "event_type": "FOUND",
-        "target": waiting_player_name,
-        "created_session": created_session_id
-    })
-
-
-async def create_session(first_player: str, second_player: str):
-    session = await session_service_adapter.create_session(first_player, second_player)
-    await notify_about_opponent_found(session.session_id, first_player)
-    await notify_about_opponent_found(session.session_id, second_player)
-
-
-# Endpoint
-
-
-async def start_search(player_name: str, rating: int, parameters: SearchParameters) -> SuccessMessage:
-    if player_name in db:
-        raise ResponseError(error_type="already_started", detail=f"Search opponent for player {player_name!r} already started")
-
-    opponent = find_player(parameters)
-
-    if opponent is not None:
-        await create_session(player_name, opponent.name)
-    else:
-        db[player_name] = WaitingPlayer(name=player_name, rating=rating, parameters=parameters)
-
-    return SuccessMessage()
-
-
-async def cancel_search(player_name: str) -> SuccessMessage:
-    if player_name not in db:
-        raise ResponseError(error_type="not_found", detail=f"Search for player {player_name!r} not started")
-
-    del db[player_name]
-    return SuccessMessage()
-
-
-# Bindings
-
-
-service.bind("start", start_search)
-service.bind("cancel", cancel_search)
-
-
-async def main():
-    global session_service_adapter
-
-    session_service_adapter = SessionServiceAdapter()
-
-    await room_events_publisher.connect()
-    await session_service_adapter.connect()
-    await service.run()
-    await asyncio.Future()
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
+if __name__ == '__main__':
+    try:
+        asyncio.run(init_infrastructure())
+    except (KeyboardInterrupt, InterruptedError):
+        asyncio.run(close_infrastructure())

--- a/services/searcher_service/methods.py
+++ b/services/searcher_service/methods.py
@@ -1,0 +1,33 @@
+from contracts import searcher_service
+from contracts.searcher_service import CallerInfo, SearchParameters
+from services.searcher_service import domain
+from services.searcher_service.domain import models, adapters
+
+
+class Implementation(searcher_service.Contract):
+    def __init__(self, database: adapters.WaitingPlayersStorage, client: adapters.SessionServiceAdapter):
+        self._database = database
+        self._client = client
+
+    @staticmethod
+    def _serialize_player(caller: CallerInfo, parameters: SearchParameters):
+        params = models.SearchParameters(min_rating=parameters.min_rating, max_rating=parameters.max_rating)
+        player = models.WaitingPlayer(name=caller.name, rating=caller.rating, parameters=params)
+
+        return player
+
+    async def start_search(self, caller: CallerInfo, parameters: SearchParameters):
+        try:
+            player = self._serialize_player(caller, parameters)
+            await domain.StartSearch(self._database, self._client)(player)
+
+        except adapters.AlreadyExists:
+            raise searcher_service.SearchAlreadyStarted(caller=caller)
+
+    async def cancel_search(self, caller: CallerInfo):
+        try:
+            player = self._serialize_player(caller, searcher_service.SearchParameters(min_rating=0, max_rating=0))
+            await domain.CancelSearch(self._database)(player)
+
+        except adapters.NotExists:
+            raise searcher_service.SearchNotStarted(caller=caller)

--- a/services/session_service/command_parser.py
+++ b/services/session_service/command_parser.py
@@ -1,0 +1,21 @@
+from contracts import session_service
+from game_model.commands.move_figure.command import MoveFigure
+from game_model.commands.resign import Resign
+from game_model.game.manager.command import Command
+from game_model.game.model import Position
+from services.session_service.domain.models import PlayerModel
+
+
+def parse_command(player: PlayerModel, command: dict) -> Command:
+    try:
+        command_id = command["command_id"]
+
+        if command_id == "turn.move":
+            start = Position(*command["from"])
+            end = Position(*command["to"])
+            return MoveFigure(player=player, start=start, end=end)
+
+        if command_id == "turn.resign":
+            return Resign(player=player)
+    except:
+        raise session_service.ExecuteCommandError(description='Invalid format')

--- a/services/session_service/domain/adapters.py
+++ b/services/session_service/domain/adapters.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+from .models import SessionModel
+
+
+class NotExists(Exception):
+    _tmp: str = "Session with id '{session_id}' not exists"
+    session_id: int
+
+    def __init__(self, session_id: int):
+        super().__init__(self._tmp.format(session_id=session_id))
+        self.session_id = session_id
+
+
+class SessionStorage(ABC):
+    @abstractmethod
+    async def create(self, first_player_name: str, second_player_name: str) -> SessionModel:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def get(self, session_id: int) -> SessionModel:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def update(self, updated_data: SessionModel) -> SessionModel:
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def remove(self, session_id: int):
+        raise NotImplementedError()

--- a/services/session_service/domain/events.py
+++ b/services/session_service/domain/events.py
@@ -1,0 +1,38 @@
+import pydantic
+from aievents import Events
+
+from game_model.game.model import GameState
+from services.session_service.domain.models import PlayerModel
+
+
+class OnPlayerConnectedMessage(pydantic.BaseModel):
+    session_id: int
+    player_name: str
+
+
+class OnPlayerDisconnectedMessage(pydantic.BaseModel):
+    session_id: int
+    player_name: str
+
+
+class OnStateChangedMessage(pydantic.BaseModel):
+    session_id: int
+    state: GameState
+
+
+class OnGameEndedMessage(pydantic.BaseModel):
+    session_id: int
+    winner: PlayerModel
+
+
+class SessionEvents(Events):
+    __events__ = (
+        'on_player_connected',
+        'on_player_disconnected',
+        'on_state_changed',
+        'on_game_ended'
+    )
+
+
+session_events = SessionEvents()
+

--- a/services/session_service/domain/factories.py
+++ b/services/session_service/domain/factories.py
@@ -1,0 +1,30 @@
+from game_model.figures import Lion, Elephant, Giraffe, Chicken
+from game_model.game.manager import GameManager
+from game_model.game.model import GameState, Player, Board, Position, GameStatus, Prison
+
+
+def state_factory(first_player: Player, second_player: Player) -> GameState:
+    board = Board(size=(3, 5))
+
+    board.get_cell(Position(0, 0)).put_figure(Elephant(owner=first_player))
+    board.get_cell(Position(1, 0)).put_figure(Lion(owner=first_player))
+    board.get_cell(Position(2, 0)).put_figure(Giraffe(owner=first_player))
+    board.get_cell(Position(1, 1)).put_figure(Chicken(owner=first_player))
+
+    board.get_cell(Position(2, 4)).put_figure(Elephant(owner=second_player))
+    board.get_cell(Position(1, 4)).put_figure(Lion(owner=second_player))
+    board.get_cell(Position(0, 4)).put_figure(Giraffe(owner=second_player))
+    board.get_cell(Position(1, 3)).put_figure(Chicken(owner=second_player))
+
+    return GameState(
+        first_player=first_player, second_player=second_player,
+        status=GameStatus.FIRST_PLAYER_TURN,
+        board=board,
+        first_player_prison=Prison(owner=first_player),
+        second_player_prison=Prison(owner=second_player)
+    )
+
+
+def manager_factory(start_state: GameState) -> GameManager:
+    manager = GameManager(start_state=start_state)
+    return manager

--- a/services/session_service/domain/models.py
+++ b/services/session_service/domain/models.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Tuple
+
+from game_model.game.manager.command import Command
+from game_model.game.model import GameState, Player
+from services.session_service.domain.factories import manager_factory
+
+
+class PlayerNotInSession(Exception):
+    _tmp = "Player '{player_name}' not in session '{session_id}'"
+
+    def __init__(self, session_id: int, player_name: str):
+        super().__init__(self._tmp.format(session_id=session_id, player_name=player_name))
+        self.session_id = session_id
+        self.player_name = player_name
+
+
+class PlayerConnectionState(str, Enum):
+    CONNECTED = "connected"
+    DISCONNECTED = "disconnected"
+
+
+@dataclass
+class PlayerModel(Player):
+    _name: str
+
+    def __post_init__(self):
+        super().__init__()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __repr__(self):
+        return f"Player({self._name!r})"
+
+
+@dataclass
+class SessionModel:
+    _session_id: int
+    _players: Tuple[PlayerModel, PlayerModel]
+    _player_connections: Dict[str, PlayerConnectionState]
+    _state: GameState
+
+    @property
+    def id(self):
+        return self._session_id
+
+    @property
+    def state(self) -> GameState:
+        return self._state
+
+    def get_player(self, player_name: str) -> PlayerModel:
+        for player in self._players:
+            if player.name == player_name:
+                return player
+
+        raise PlayerNotInSession(session_id=self.id, player_name=player_name)
+
+    def get_players(self) -> Tuple[PlayerModel, PlayerModel]:
+        return self._players
+
+    def execute_command(self, command: Command):
+        manager = manager_factory(self._state)
+        manager.send_command(command)
+        self._state = manager.game_state
+
+    def connect(self, player_name: str):
+        player = self.get_player(player_name)
+        self._player_connections[player.name] = PlayerConnectionState.CONNECTED
+
+    def disconnect(self, player_name: str):
+        player = self.get_player(player_name)
+        self._player_connections[player.name] = PlayerConnectionState.DISCONNECTED

--- a/services/session_service/domain/usecases.py
+++ b/services/session_service/domain/usecases.py
@@ -1,0 +1,107 @@
+from game_model.game.manager.command import Command
+from game_model.game.model import GameStatus
+from services.session_service.domain.adapters import SessionStorage
+from services.session_service.domain.events import *
+from services.session_service.domain.models import SessionModel
+
+
+class CreateSession:
+    _storage: SessionStorage
+
+    def __init__(self, storage: SessionStorage):
+        self._storage = storage
+
+    async def __call__(self, first_player_name: str, second_player_name: str) -> SessionModel:
+        session = await self._storage.create(first_player_name, second_player_name)
+        print(session)
+        session.disconnect(first_player_name)
+        session.disconnect(second_player_name)
+        await self._storage.update(session)
+
+        return session
+
+
+class ConnectToSession:
+    _storage: SessionStorage
+
+    def __init__(self, storage: SessionStorage):
+        self._storage = storage
+
+    async def __call__(self, player_name: str, session_id: int):
+        session = await self._storage.get(session_id)
+        session.connect(player_name=player_name)
+        await self._storage.update(session)
+
+        await session_events.on_player_connected(OnPlayerConnectedMessage(
+            session_id=session_id,
+            player_name=player_name
+        ))
+
+
+class DisconnectFromSession:
+    _storage: SessionStorage
+
+    def __init__(self, storage: SessionStorage):
+        self._storage = storage
+
+    async def __call__(self, player_name: str, session_id: int):
+        session = await self._storage.get(session_id)
+        await session.disconnect(player_name=player_name)
+        await self._storage.update(session)
+
+        await session_events.on_player_disconnected(OnPlayerDisconnectedMessage(
+            session_id=session_id,
+            player_name=player_name
+        ))
+
+
+class GetPlayer:
+    _storage: SessionStorage
+
+    def __init__(self, storage: SessionStorage):
+        self._storage = storage
+
+    async def __call__(self, player_name: str, session_id: int):
+        session = await self._storage.get(session_id)
+        return session.get_player(player_name)
+
+
+class ExecuteCommand:
+    _storage: SessionStorage
+
+    def __init__(self, storage: SessionStorage):
+        self._storage = storage
+
+    async def __call__(self, session_id: int, command: Command):
+        session = await self._storage.get(session_id)
+        await session.execute_command(command)
+        await self._storage.update(session)
+
+        await session_events.on_state_changed(OnStateChangedMessage(
+            session_id=session_id,
+            changed_state=session.state
+        ))
+
+        if session.state.status == GameStatus.SECOND_PLAYER_WIN:
+            await session_events.on_game_ended(OnGameEndedMessage(
+                session_id=session.id,
+                winner=session.get_players()[1]
+            ))
+            await self._storage.remove(session_id)
+
+        if session.state.status == GameStatus.FIRST_PLAYER_WIN:
+            await session_events.on_game_ended(OnGameEndedMessage(
+                session_id=session.id,
+                winner=session.get_players()[0]
+            ))
+            await self._storage.remove(session_id)
+
+
+class GetSession:
+    _storage: SessionStorage
+
+    def __init__(self, storage: SessionStorage):
+        self._storage = storage
+
+    async def __call__(self, session_id: int) -> SessionModel:
+        return await self._storage.get(session_id)

--- a/services/session_service/event_handlers.py
+++ b/services/session_service/event_handlers.py
@@ -1,0 +1,51 @@
+from amqp_events import AmqpEventPublisher
+from services.session_service.domain.events import *
+from state_encoder import StateEncoder
+
+amqp_publisher = AmqpEventPublisher(event_name='session_service.sessions.events')
+
+
+async def on_state_changed(message: OnStateChangedMessage):
+    message = {
+        "event_type": 'STATE_CHANGED',
+        "session_id": message.session_id,
+        "changed_state": StateEncoder.encode(message.state)
+    }
+
+    await amqp_publisher.notify(message)
+
+
+async def on_player_connected(message: OnPlayerConnectedMessage):
+    message = {
+        "event_type": 'PLAYER_CONNECTED',
+        "session_id": message.session_id,
+        "player_name": message.player_name
+    }
+
+    await amqp_publisher.notify(message)
+
+
+async def on_player_disconnected(message: OnPlayerDisconnectedMessage):
+    message = {
+        "event_type": 'PLAYER_DISCONNECTED',
+        "session_id": message.session_id,
+        "player_name": message.player_name
+    }
+
+    await amqp_publisher.notify(message)
+
+
+async def on_game_ended(message: OnGameEndedMessage):
+    message = {
+        "event_type": SessionEvents.GAME_ENDED.value,
+        "session_id": message.session_id,
+        "winner": message.winner.name
+    }
+
+    await amqp_publisher.notify(message)
+
+
+session_events.on_state_changed += on_state_changed
+session_events.on_player_connected += on_player_connected
+session_events.on_player_disconnected += on_player_disconnected
+session_events.on_game_ended += on_game_ended

--- a/services/session_service/infrastructure/__init__.py
+++ b/services/session_service/infrastructure/__init__.py
@@ -1,0 +1,6 @@
+from .session_database import SessionDatabase
+
+
+__all__ = [
+    'SessionDatabase'
+]

--- a/services/session_service/infrastructure/session_database.py
+++ b/services/session_service/infrastructure/session_database.py
@@ -1,0 +1,95 @@
+import json
+
+from tortoise import Model, fields, Tortoise
+from services.session_service.domain.adapters import SessionStorage, NotExists
+from services.session_service.domain.factories import state_factory
+from services.session_service.domain.models import SessionModel, PlayerConnectionState, PlayerModel
+from settings import settings
+from state_encoder import StateEncoder
+
+
+class SessionDBModel(Model):
+    id = fields.IntField(pk=True)
+    connected_players: fields.ReverseRelation['SessionPlayerDBModel']
+    state = fields.JSONField(
+        encoder=lambda x: json.dumps(StateEncoder.encode(x)),
+        decoder=lambda x: StateEncoder.decode(json.loads(x))
+    )
+
+
+class SessionPlayerDBModel(Model):
+    name = fields.TextField()
+    connection_state = fields.CharEnumField(PlayerConnectionState, default=PlayerConnectionState.DISCONNECTED)
+    connected_session: fields.ForeignKeyRelation[SessionDBModel] = fields.ForeignKeyField(
+        'models.SessionDBModel', related_name='connected_players'
+    )
+
+
+class SessionDatabase(SessionStorage):
+    async def connect(self):
+        await Tortoise.init(
+            db_url=settings.postgres_dsn,
+            modules={'models': ['services.session_service.infrastructure.session_database']}
+        )
+
+        await Tortoise.generate_schemas()
+
+    async def _serialize_session(self, record: SessionDBModel) -> SessionModel:
+        player_records = await record.connected_players.all()
+        first_player, second_player = [PlayerModel(_name=player.name) for player in player_records]
+
+        return SessionModel(
+            _session_id=record.id,
+            _players=(first_player, second_player),
+            _player_connections={
+                first_player.name: player_records[0].connection_state,
+                second_player.name: player_records[1].connection_state
+            },
+            _state=record.state
+        )
+
+    async def create(self, first_player_name: str, second_player_name: str) -> SessionModel:
+        first_player, second_player = PlayerModel(first_player_name), PlayerModel(second_player_name)
+        state = state_factory(first_player=first_player, second_player=second_player)
+
+        session_record = await SessionDBModel.create(state=state)
+        await SessionPlayerDBModel.create(name=first_player.name, connected_session=session_record)
+        await SessionPlayerDBModel.create(name=second_player_name, connected_session=session_record)
+
+        return await self._serialize_session(session_record)
+
+    async def get(self, session_id: int) -> SessionModel:
+        record = await SessionDBModel.filter(id=session_id).first()
+
+        if record is None:
+            raise NotExists(session_id=session_id)
+
+        return await self._serialize_session(record)
+
+    async def update(self, updated_data: SessionModel) -> SessionModel:
+        record = await SessionDBModel.filter(id=updated_data.id).first()
+
+        if record is None:
+            raise NotExists(session_id=updated_data.id)
+
+        players = await record.connected_players.all()
+        record.state = updated_data.state
+        players[0].connection_state = updated_data._player_connections[players[0].name]
+        players[1].connection_state = updated_data._player_connections[players[1].name]
+
+        await players[0].save()
+        await players[1].save()
+        await record.save()
+
+        return updated_data
+
+    async def remove(self, session_id: int):
+        record = await SessionDBModel.filter(id=session_id).first()
+
+        if record is None:
+            raise NotExists(session_id=session_id)
+
+        for player in record.connected_players:
+            await player.delete()
+
+        await record.delete()

--- a/services/session_service/main.py
+++ b/services/session_service/main.py
@@ -1,0 +1,25 @@
+import asyncio
+from contracts import session_service
+from rpc_service import RpcServiceBuilder
+from rpc_service.utils import ServiceLauncher
+from services.session_service import event_handlers
+from services.session_service.infrastructure.session_database import SessionDatabase
+from services.session_service.methods import Implementation
+from settings import settings
+
+
+db = SessionDatabase()
+implementation = Implementation(database=db)
+
+service = RpcServiceBuilder.from_contract(implementation, session_service.Contract)
+launcher = ServiceLauncher(service)
+
+
+async def main():
+    await db.connect()
+    await event_handlers.amqp_publisher.connect(settings.amqp_dsn)
+    await launcher.start(settings.amqp_dsn)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/services/session_service/methods.py
+++ b/services/session_service/methods.py
@@ -1,0 +1,70 @@
+from contracts import session_service
+from game_model.game.manager.exceptions import ExecuteCommandException
+from services.session_service.command_parser import parse_command
+from services.session_service.domain import adapters, models
+from services.session_service.domain.usecases import *
+
+
+class Implementation(session_service.Contract):
+    def __init__(self, database: adapters.SessionStorage):
+        self._database = database
+
+    async def create_session(self, first_player: str, second_player: str) -> session_service.Session:
+        created_session = await CreateSession(storage=self._database)(
+            first_player_name=first_player,
+            second_player_name=second_player)
+
+        players = created_session.get_players()
+
+        response = session_service.Session(
+            session_id=created_session.id,
+            first_player=players[0].name,
+            second_player=players[1].name
+        )
+        return response
+
+    async def connect_to_session(self, session_id: int, player_name: str):
+        try:
+            await ConnectToSession(storage=self._database)(session_id=session_id, player_name=player_name)
+
+        except models.PlayerNotInSession:
+            raise session_service.AccessDenied(session_id=session_id, player_name=player_name)
+
+        except adapters.NotExists:
+            raise session_service.NotExists(session_id=session_id)
+
+    async def disconnect_from_session(self, session_id: int, player_name: str):
+        try:
+            await DisconnectFromSession(storage=self._database)(
+                session_id=session_id,
+                player_name=player_name)
+
+        except models.PlayerNotInSession:
+            raise session_service.AccessDenied(session_id=session_id, player_name=player_name)
+
+        except adapters.NotExists:
+            raise session_service.NotExists(session_id=session_id)
+
+    async def execute_command(self, session_id: int, player_name: str, command: dict):
+        try:
+            player = await GetPlayer(self._database)(player_name, session_id)
+            parsed_command = parse_command(player, command)
+            await ExecuteCommand(self._database)(session_id, parsed_command)
+
+        except ExecuteCommandException as e:
+            raise session_service.ExecuteCommandError(description=str(e))
+
+        except models.PlayerNotInSession:
+            raise session_service.AccessDenied(session_id=session_id, player_name=player_name)
+
+        except adapters.NotExists:
+            raise session_service.NotExists(session_id=session_id)
+
+    async def get_session_game_state(self, session_id: int) -> session_service.GameStateResponse:
+        try:
+            session = await GetSession(self._database)(session_id=session_id)
+
+        except adapters.NotExists:
+            raise session_service.NotExists(session_id=session_id)
+
+        return session_service.GameStateResponse(state=session.state)


### PR DESCRIPTION
Улучшили решение задачи организации общих зависимостей между клиентами и rpc сервисами в коде. Реализовали для этого пакет rpc_service и amqp_events, помогающие шаблонизировать описание интерфейсов сервисов.

Добавили к сервисами реализации хранилищ на основе tortoise orm. Все записи хранятся на portgres orm

Выделили все системные зависимости проекта в отдельную модель ProjectSettings, чтобы иметь единственную точку доступа к ним.

@aRussianSweetie 
- Поменял сервисы авторизации, приватных комнат и поиска соперника
- Добавил API роутеры к этим сервисам

@Nifacy 
- Поменял сервисы аккаунтов и игровых сессий
- Добавил API роутеры к ним
- Добавил файлы схем и зависимостей между роутерами
- Добавил файл, запускающий gateway сервис